### PR TITLE
chore(oas): herbruikbare BRP schema componenten

### DIFF
--- a/specificatie/brp-api/fields-v1.yaml
+++ b/specificatie/brp-api/fields-v1.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+info:
+  title: Fields
+  description: |
+    Definities voor Fields en Field, parameters waarmee een consumer aangeeft welke velden van een Resource moet worden geleverd.  
+  version: 1.0.0
+components:
+  schemas:
+    Field:
+      description: |
+        Het pad naar een gewenst veld in punt-gescheiden formaat. Bijvoorbeeld "burgerservicenummer", "geboorte.datum", "partners.naam.voornamen".
+      type: string
+      pattern: ^[a-zA-Z0-9\._]{1,200}$
+    Fields:
+      description: |
+        Een lijst van minimaal 1 en maximaal 130 Field parameters
+      type: array
+      maxItems: 130
+      minItems: 1
+      items:
+        $ref: '#/components/schemas/Field'

--- a/specificatie/brp/burgerservicenummer-v1.yaml
+++ b/specificatie/brp/burgerservicenummer-v1.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: Burgerservicenummer
+  description: |
+    Definitie voor burgerservicenummer, een identificatienummer van een persoon geregistreerd in de BRP
+  version: 1.0.0
+  contact: {}
+components:
+  schemas:
+    Burgerservicenummer:
+      type: string
+      pattern: ^[0-9]{9}$
+      example: "555555021"

--- a/specificatie/brp/datum-gba-v1.yaml
+++ b/specificatie/brp/datum-gba-v1.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: GBA datum
+  description: |
+    Definitie voor een datum conform LO GBA
+  version: 1.0.0
+  contact: {}
+components:
+  schemas:
+    GbaDatum:
+      type: string
+      pattern: ^[0-9]{8}$
+      example: "20180700"

--- a/specificatie/brp/datum-v1.yaml
+++ b/specificatie/brp/datum-v1.yaml
@@ -1,0 +1,113 @@
+openapi: 3.1.0
+info:
+  title: Datum
+  description: |
+    Definities voor de volgende datum types:
+    - onbekend datum
+    - 'volledig' datum conform ISO-8601
+    - datum waarvan de dag onbekend is
+    - datum waarvan de maand en dag onbekend is
+  version: 1.0.0
+  contact: {}
+components:
+  schemas:
+    AbstractDatum:
+      type: object
+      required:
+        - type
+        - langFormaat
+      properties:
+        type:
+          type: string
+        langFormaat:
+          type: string
+          pattern: ^[a-z0-9 ]{1,17}$
+      discriminator:
+        propertyName: type
+        mapping:
+          Datum: '#/components/schemas/VolledigeDatum'
+          DatumOnbekend: '#/components/schemas/DatumOnbekend'
+          JaarDatum: '#/components/schemas/JaarDatum'
+          JaarMaandDatum: '#/components/schemas/JaarMaandDatum'
+
+    VolledigeDatum:
+      description: Datum conform iso8601
+      allOf:
+        - $ref: '#/components/schemas/AbstractDatum'
+        - type: object
+          properties:
+            datum:
+              type: string
+              format: date
+      required:
+        - datum
+      example:
+        value:
+          type: Datum
+          datum: "2018-07-01"
+          langFormaat: "1 juli 2018"
+
+    DatumOnbekend:
+      description: representatie voor een volledig onbekend datum
+      allOf:
+        - $ref: '#/components/schemas/AbstractDatum'
+        - type: object
+          properties:
+            onbekend:
+              type: boolean
+              default: true
+      required:
+        - onbekend
+      example:
+        value:
+          type: DatumOnbekend
+          onbekend: true
+          langFormaat: "onbekend"
+
+    JaarDatum:
+      description: representatie voor een datum waarvan maand en dag onbekend zijn
+      allOf:
+        - $ref: '#/components/schemas/AbstractDatum'
+        - type: object
+          properties:
+            jaar:
+              $ref: '#/components/schemas/Jaar'
+      required:
+        - jaar
+      example:
+        value:
+          type: JaarDatum
+          jaar: 2018
+          langFormaat: 2018
+
+    JaarMaandDatum:
+      description: representatie voor een datum waarvan de dag onbekend is
+      allOf:
+        - $ref: '#/components/schemas/AbstractDatum'
+        - type: object
+          properties:
+            jaar:
+              $ref: '#/components/schemas/Jaar'
+            maand:
+              $ref: '#/components/schemas/Maand'
+      required:
+        - jaar
+        - maand
+      example:
+        value:
+          type: JaarMaandDatum
+          jaar: 2018
+          maand: 7
+          langFormaat: "juli 2018"
+
+    Jaar:
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 9999
+
+    Maand:
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 12

--- a/specificatie/problem-details/bad-request-fout-bericht-v1.yaml
+++ b/specificatie/problem-details/bad-request-fout-bericht-v1.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.0
+info:
+  title: BadRequestFoutbericht
+  description: |
+    Definitie voor BadRequestFoutbericht, voor het leveren van input validatie foutmeldingen 
+  version: 1.0.0
+  contact: {}
+components:
+  schemas:
+    BadRequestFoutbericht:
+      allOf:
+      - $ref: 'fout-bericht-v1.yaml#/components/schemas/Foutbericht'
+      - type: object
+        properties:
+          invalidParams:
+            description: |
+              Foutmelding per fout in een parameter. Alle gevonden fouten worden één keer teruggemeld.
+            type: array
+            items:
+              $ref: 'invalid-param-v1.yaml#/components/schemas/InvalidParams'

--- a/specificatie/problem-details/fout-bericht-v1.yaml
+++ b/specificatie/problem-details/fout-bericht-v1.yaml
@@ -1,0 +1,39 @@
+openapi: 3.1.0
+info:
+  title: Foutbericht
+  description: |
+    Definitie voor Foutbericht, een JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
+  version: 1.0.0
+  contact: {}
+components:
+  schemas:
+    Foutbericht:
+      type: object
+      description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Link naar meer informatie over deze fout
+        title:
+          type: string
+          pattern: ^[a-zA-Z0-9À-ž \.\-]{1,80}$
+          description: Beschrijving van de fout
+        status:
+          type: integer
+          minimum: 100
+          maximum: 600
+          description: Http status code
+        detail:
+          type: string
+          pattern: ^[a-zA-Z0-9À-ž \.\-\(\)\,]{1,200}$
+          description: Details over de fout
+        instance:
+          type: string
+          format: uri
+          description: Uri van de aanroep die de fout heeft veroorzaakt
+        code:
+          type: string
+          pattern: ^[a-zA-Z0-9]{1,25}$
+          description: Systeemcode die het type fout aangeeft
+          minLength: 1

--- a/specificatie/problem-details/invalid-param-v1.yaml
+++ b/specificatie/problem-details/invalid-param-v1.yaml
@@ -1,0 +1,33 @@
+openapi: 3.1.0
+info:
+  title: InvalidParams
+  description: |
+    Definitie voor InvalidParams, voor het leveren van details over fouten in een opgegeven parameter
+  version: 1.0.0
+  contact: {}
+components:
+  schemas:
+    InvalidParams:
+      type: object
+      description: Details over fouten in opgegeven parameters
+      properties:
+        type:
+          type: string
+          format: uri
+          example: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1
+        name:
+          type: string
+          pattern: ^[a-zA-Z0-9\.,_]{1,30}$
+          description: Naam van de parameter
+          example: "huisnummer"
+        code:
+          type: string
+          pattern: ^[a-zA-Z0-9\.,_]{1,25}$
+          description: Systeemcode die het type fout aangeeft
+          minLength: 1
+          example: "integer"
+        reason:
+          type: string
+          pattern: ^[a-zA-Z0-9\.,_ ]{1,80}$
+          description: Beschrijving van de fout op de parameterwaarde
+          example: Waarde is geen geldig getal.


### PR DESCRIPTION
Opzetten structuur voor het vergemakkelijken van hergebruiken van BRP schema componenten gespecificeerd m.b.v. OAS

Design keuzes:
- uit de bestandsnamen moet kunnen worden afgeleid welke definities er al zijn
- uit de bestandsnamen moet kunnen worden afgeleid hoeveel versies er voor een definitie zijn en wat de laatste versie is
- een breaking change in een definitie wordt gespecificeerd in een nieuw bestand waardoor een API provider zelf kan bepalen wanneer hij zal upgraden