### PR TITLE
chore(automation): fout bij veld met waarde null in response gefixed

### DIFF
--- a/features/docs/dan-stap-definities-algemeen.feature
+++ b/features/docs/dan-stap-definities-algemeen.feature
@@ -1,0 +1,30 @@
+#language: nl
+
+@skip-verify
+Functionaliteit: Geen javascript fout bij ongeldig response
+
+  Scenario: naam veld in de response heeft de waarde null
+    Gegeven de response body is gelijk aan
+    """
+    {
+      "personen": [
+        {
+          "naam": null
+        }
+      ]
+    }
+    """
+    Dan heeft de response geen personen
+
+  Scenario: naam veld in de response heeft de waarde undefined
+    Gegeven de response body is gelijk aan
+    """
+    {
+      "personen": [
+        {
+          "naam": undefined
+        }
+      ]
+    }
+    """
+    Dan heeft de response geen personen

--- a/features/step_definitions/stringify.js
+++ b/features/step_definitions/stringify.js
@@ -1,6 +1,8 @@
 function stringifyValues(o) {
     if(o === undefined) return o;
 
+    if(o === null) return 'null';
+    
     Object.keys(o).forEach(k => {
         if (typeof o[k] === 'object') {
             o[k] = stringifyValues(o[k]);

--- a/scripts/specs-verify.sh
+++ b/scripts/specs-verify.sh
@@ -4,4 +4,6 @@ npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-zonder-dependency-integratie-summary.txt \
                 -f summary \
                 features/docs \
-                --tags "not @integratie"
+                --tags "not @integratie" \
+                --tags "not @skip-verify"
+


### PR DESCRIPTION
De scenarios in dan-stap-definities-algemeen.feature kunnen worden gebruikt om te valideren dat de automation code geen javascript fout geeft als de response een veld met waarde null/undefined heeft, maar wel een assertion fout zodat de ongeldige reponse wordt getoond, zoals:

```
       AssertionError: actual: {
        "personen": [
                {
                        "naam": "null"
                }
        ]
       }
       expected: {
        "personen": []
       }: expected { personen: [ { naam: 'null' } ] } to deeply equal { personen: [] }
           + expected - actual

            {
           -  "personen": [
           -    {
           -      "naam": "null"
           -    }
           -  ]
           +  "personen": []
            }

           at Proxy.equalInAnyOrder (C:\Projects\brp-api\brp-shared\node_modules\deep-equal-in-any-order\build\index.js:33:10)
           at Proxy.methodWrapper (C:\Projects\brp-api\brp-shared\node_modules\chai\lib\chai\utils\addMethod.js:57:25)
           at vergelijkActualMetExpected (C:\Projects\brp-api\brp-shared\features\step_definitions\responseHelpers.js:50:28)
           at valideer200Response (C:\Projects\brp-api\brp-shared\features\step_definitions\responseHelpers.js:74:5)
           at World.<anonymous> (C:\Projects\brp-api\brp-shared\features\step_definitions\stepdefs.js:14:5)
```