### PR TITLE
automation documentatie: valideer bewoners volgens opgegeven volgorde scenarios toegevoegd

### DIFF
--- a/features/docs/dan-stap-definities-volgorde-validatie.feature
+++ b/features/docs/dan-stap-definities-volgorde-validatie.feature
@@ -6,7 +6,10 @@ Functionaliteit: volgorde validatie
   Als team lid
   wil ik kunnen aangeven dat een response body volgens de gespecificeerde volgorde moet worden gevalideerd
 
-  Achtergrond:
+Regel: De response wordt volgens de opgegeven volgorde gevalideerd wanneer de '@valideer-volgorde' tag is toegevoegd aan een scenario/feature
+
+  @valideer-volgorde
+  Scenario: de '@valideer-volgorde' tag is opgegeven
     Gegeven de response body is gelijk aan
     """
     {
@@ -20,17 +23,25 @@ Functionaliteit: volgorde validatie
       ]
     }
     """
-
-Regel: De response wordt volgens de opgegeven volgorde gevalideerd wanneer de '@valideer-volgorde' tag is toegevoegd aan een scenario/feature
-
-  @valideer-volgorde
-  Scenario: de '@valideer-volgorde' tag is opgegeven
     Dan heeft de response verblijfplaatsen met de volgende gegevens
     | adresseerbaarObjectIdentificatie |
     | 0800010000000001                 |
     | 0800010000000002                 |
 
   Abstract Scenario: de '@valideer-volgorde' tag is niet opgegeven
+    Gegeven de response body is gelijk aan
+    """
+    {
+      "verblijfplaatsen": [
+        {
+          "adresseerbaarObjectIdentificatie": "0800010000000001"
+        },
+        {
+          "adresseerbaarObjectIdentificatie": "0800010000000002"
+        }
+      ]
+    }
+    """
     Dan heeft de response verblijfplaatsen met de volgende gegevens
     | adresseerbaarObjectIdentificatie |
     | <ado id 1>                       |
@@ -40,3 +51,65 @@ Regel: De response wordt volgens de opgegeven volgorde gevalideerd wanneer de '@
     | ado id 1         | ado id 2         |
     | 0800010000000001 | 0800010000000002 |
     | 0800010000000002 | 0800010000000001 |
+
+  @valideer-volgorde
+  Scenario: de '@valideer-volgorde' tag is opgegeven
+    Gegeven de response body is gelijk aan
+    """
+    {
+      "bewoningen": [
+        {
+          "adresseerbaarObjectIdentificatie": "0800010000000001",
+          "bewoners": [
+            {
+              "burgerservicenummer": "000000024"
+            },
+            {
+              "burgerservicenummer": "000000012"
+            }
+          ],
+          "mogelijkeBewoners": []
+        }
+      ]
+    }
+    """
+    Dan heeft de response een bewoning met de volgende gegevens
+    | adresseerbaarObjectIdentificatie |
+    | 0800010000000001                 |
+    En heeft de bewoning bewoners met de volgende gegevens
+    | burgerservicenummer |
+    | 000000024           |
+    | 000000012           |
+
+  Abstract Scenario: de '@valideer-volgorde' tag is opgegeven
+    Gegeven de response body is gelijk aan
+    """
+    {
+      "bewoningen": [
+        {
+          "adresseerbaarObjectIdentificatie": "0800010000000001",
+          "bewoners": [
+            {
+              "burgerservicenummer": "000000024"
+            },
+            {
+              "burgerservicenummer": "000000012"
+            }
+          ],
+          "mogelijkeBewoners": []
+        }
+      ]
+    }
+    """
+    Dan heeft de response een bewoning met de volgende gegevens
+    | adresseerbaarObjectIdentificatie |
+    | 0800010000000001                 |
+    En heeft de bewoning bewoners met de volgende gegevens
+    | burgerservicenummer     |
+    | <burgerservicenummer 1> |
+    | <burgerservicenummer 2> |
+
+    Voorbeelden:
+    | burgerservicenummer 1 | burgerservicenummer 2 |
+    | 000000024             | 000000012             |
+    | 000000012             | 000000024             |


### PR DESCRIPTION
Deze p.r. bevat voorbeelden die laten zien dat door toevoeging van de `valideer-volgorde` tag aan een scenario de opgegeven volgorde van bewoners wordt gevalideerd