### PR TITLE
chore: convert feature naar markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "commitizen": "^4.3.1",
         "cz-conventional-changelog": "^3.3.0",
         "deep-equal-in-any-order": "^2.0.6",
+        "gherkin-io": "^1.3.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "multiple-cucumber-html-reporter": "^3.9.2",
@@ -4089,6 +4090,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -6750,6 +6761,134 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gherkin-ast": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/gherkin-ast/-/gherkin-ast-3.4.2.tgz",
+      "integrity": "sha512-ftwmkgxyjq43OqbY7Cg2ICix+mGTQaomj+m14bHXFwDJoRirFcMIDN0+JlIwHgpm6kxkpIQ2IDSQy2knCMzvkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "object-scan": "^17.1.0",
+        "object-set-type": "^2.2.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gherkin-ast/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gherkin-formatter": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/gherkin-formatter/-/gherkin-formatter-1.2.2.tgz",
+      "integrity": "sha512-sKySjTvnrxqiOyh5UZAbcpF2EjutUb6SkNyry5fUV9mErDXOhMzlFVz2JCEyt7eBkHzQ32JT/rACQF1//+6TmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "gherkin-ast": "^3.4.1",
+        "lines-builder": "^1.5.1",
+        "table": "^6.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gherkin-io": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gherkin-io/-/gherkin-io-1.3.0.tgz",
+      "integrity": "sha512-ykH9c4ObEA0owtiQYtt3mjZR9vox8xv2DX8ITvdQjaVOIugxYceK+U1AZD3szm2iulMf5u0tBg3pWThGPg3d8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/gherkin": "^27.0.0",
+        "@cucumber/gherkin-streams": "^5.0.1",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "gherkin-ast": "^3.4.0",
+        "gherkin-formatter": "^1.2.0",
+        "glob": "^10.3.10"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gherkin-io/node_modules/@cucumber/gherkin": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-27.0.0.tgz",
+      "integrity": "sha512-j5rCsjqzRiC3iVTier3sa0kzyNbkcAmF7xr7jKnyO7qDeK3Z8Ye1P3KSVpeQRMY+KCDJ3WbTDdyxH0FwfA/fIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <=22"
+      }
+    },
+    "node_modules/gherkin-io/node_modules/@cucumber/messages": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-22.0.0.tgz",
+      "integrity": "sha512-EuaUtYte9ilkxcKmfqGF9pJsHRUU0jwie5ukuZ/1NPTuHS1LxHPsGEODK17RPRbZHOFhqybNzG2rHAwThxEymg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "9.0.1",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.1.13",
+        "uuid": "9.0.0"
+      }
+    },
+    "node_modules/gherkin-io/node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gherkin-io/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/gherkin-io/node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/gherkin-io/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/git-raw-commits": {
@@ -9985,6 +10124,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lines-builder": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/lines-builder/-/lines-builder-1.5.1.tgz",
+      "integrity": "sha512-f/jpZtzBzpQ1nDNyEmXw1mrMKO8f+Foh7BJBIVYfBflbC4zAdQcpyLDtsMPV5akb0IWSRVQxhR2jTCGd9grn4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -10075,6 +10227,13 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
       "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11048,6 +11207,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-scan": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/object-scan/-/object-scan-17.1.0.tgz",
+      "integrity": "sha512-r+LfWbSftyqVBj/WqSEQ4sSCDN1T0JBVCfHp2WO3vf1ykn6IjVMKtJ34+ABvdDDGjjCgq1L8TC6yc2CV37jRwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/object-set-type": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/object-set-type/-/object-set-type-2.2.2.tgz",
+      "integrity": "sha512-SdjFAc0KLgO3DNqSkejHhvmHhj3FiW+QY2PBk37Ev/wBUBnmDiIZ/gLD4Q0DZv/VbU/pMN9XyF/jtGSWmapdJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-eql": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/object.assign": {
@@ -12880,6 +13062,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/slugify": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
@@ -13374,6 +13610,23 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "multiple-cucumber-html-reporter": "^3.9.2",
     "nswag": "^14.2.0",
     "pg": "^8.14.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "gherkin-io": "^1.3.0"
   },
   "config": {
     "commitizen": {

--- a/scripts/convert-feature-file.js
+++ b/scripts/convert-feature-file.js
@@ -34,10 +34,12 @@ function toExamplesTable(examples) {
 
 function toScenarioSection(element, tags) {
   let markdown = '';
-  let elementTags = element.tags.map(tag => tag.name);
-  const matchingTags = elementTags.filter(tag => tags.includes(tag));
-  if (matchingTags.length === 0) {
-    return '';
+  if (tags.length > 0) {
+    let elementTags = element.tags.map(tag => tag.name);
+    const matchingTags = elementTags.filter(tag => tags.includes(tag));
+    if (matchingTags.length === 0) {
+      return '';
+    }
   }
   markdown += `### ${element.keyword}: ${element.name}\n\n`;
   element.steps.forEach(step => {
@@ -54,42 +56,46 @@ function toScenarioSection(element, tags) {
 
 function toAbstractScenarioSection(element, tags) {
   let markdown = '';
-  let elementTags = element.tags.map(tag => tag.name);
-  const matchingTags = elementTags.filter(tag => tags.includes(tag));
-  if (matchingTags.length === 0) {
-    return '';
+
+  if (tags.length > 0) {
+    let elementTags = element.tags.map(tag => tag.name);
+    const matchingTags = elementTags.filter(tag => tags.includes(tag));
+    if (matchingTags.length === 0) {
+      return '';
+    }
   }
+
   const escapedName = element.name.replace(/</g, lt).replace(/>/g, gt);
-      markdown += `### ${element.keyword}: ${escapedName}\n\n`;
-      element.steps.forEach(step => {
-        markdown += `- ${step.keyword.replace(/\*/g, "-")} ${step.text.replace(/</g, lt).replace(/>/g, gt)}\n`.replace("- -", "  -");
-        if (step.dataTable) {
-          markdown += '\n';
-          markdown += toTable(step.dataTable);
-          markdown += '\n';
-        }
-      });
-
-      if (element.examples) {
-        markdown += '\n';
-        markdown += toExamplesTable(element.examples);
-        markdown += '\n';
-      }
-
+  markdown += `### ${element.keyword}: ${escapedName}\n\n`;
+  element.steps.forEach(step => {
+    markdown += `- ${step.keyword.replace(/\*/g, "-")} ${step.text.replace(/</g, lt).replace(/>/g, gt)}\n`.replace("- -", "  -");
+    if (step.dataTable) {
       markdown += '\n';
+      markdown += toTable(step.dataTable);
+      markdown += '\n';
+    }
+  });
+
+  if (element.examples) {
+    markdown += '\n';
+    markdown += toExamplesTable(element.examples);
+    markdown += '\n';
+  }
+
+  markdown += '\n';
   return markdown;
 }
 
 function toRuleSection(element, tags) {
   let markdown = '';
-  let elementTags = element.tags.map(tag => tag.name);
-  const matchingTags = elementTags.filter(tag => tags.includes(tag));
-  if (matchingTags.length === 0) {
-    return '';
+  if (tags.length > 0) {
+    let elementTags = element.tags.map(tag => tag.name);
+    const matchingTags = elementTags.filter(tag => tags.includes(tag));
+    if (matchingTags.length === 0) {
+      return '';
+    }
   }
-
   markdown += `## ${element.keyword}: ${element.name}\n\n`;
-
   if (element.elements && Array.isArray(element.elements)) {
     element.elements.forEach(ruleElement => {
 
@@ -112,7 +118,7 @@ function astToMarkdown(gherkinAST, tags) {
   let markdown = '';
 
   const feature = gherkinAST.feature;
-  markdown += `---\nlayout: page-with-side-nav\ntitle: ${feature.name}\n---\n\n`;
+  // markdown += `---\nlayout: page-with-side-nav\ntitle: ${feature.name}\n---\n\n`;
   markdown += `# ${feature.keyword}: ${feature.name}\n\n`;
 
   if (feature.description) {

--- a/scripts/convert-feature-file.js
+++ b/scripts/convert-feature-file.js
@@ -1,0 +1,161 @@
+const fs = require('fs').promises;
+const { parse } = require('gherkin-io');
+
+const lt = "\`<";
+const gt = "\>`";
+
+function toTable(dataTable) {
+  let markdown = '';
+  dataTable.rows.forEach((row, index) => {
+    markdown += `| ${row.cells.map(cell => cell.value.replace(/</g, lt).replace(/>/g, gt)).join(' | ')} |\n`;
+    if (index === 0) {
+      markdown += `| ${row.cells.map(() => '---').join(' | ')} |\n`;
+    }
+  });
+  return markdown;
+}
+
+function toExamplesTable(examples) {
+  let markdown = '';
+  examples.forEach(example => {
+    markdown += `#### ${example.keyword}\n\n`;
+    markdown += `| ${example.header.cells.map(cell => cell.value).join(' | ')} |\n`;
+    markdown += `| ${example.header.cells.map(() => '---').join(' | ')} |\n`;
+    example.body.map(body => {
+      markdown += '| ';
+      body.cells.forEach(cell => {
+        markdown += `${cell.value} |`;
+      });
+      markdown += '\n';
+    });
+  });
+  return markdown;
+}
+
+function toScenarioSection(element, tags) {
+  let markdown = '';
+  let elementTags = element.tags.map(tag => tag.name);
+  const matchingTags = elementTags.filter(tag => tags.includes(tag));
+  if (matchingTags.length === 0) {
+    return '';
+  }
+  markdown += `### ${element.keyword}: ${element.name}\n\n`;
+  element.steps.forEach(step => {
+    markdown += `- ${step.keyword.replace(/\*/g, "-")} ${step.text}\n`.replace("- -", "  -");
+    if (step.dataTable) {
+      markdown += '\n';
+      markdown += toTable(step.dataTable);
+      markdown += '\n';
+    }
+  });
+  markdown += '\n';
+  return markdown;
+}
+
+function toAbstractScenarioSection(element, tags) {
+  let markdown = '';
+  let elementTags = element.tags.map(tag => tag.name);
+  const matchingTags = elementTags.filter(tag => tags.includes(tag));
+  if (matchingTags.length === 0) {
+    return '';
+  }
+  const escapedName = element.name.replace(/</g, lt).replace(/>/g, gt);
+      markdown += `### ${element.keyword}: ${escapedName}\n\n`;
+      element.steps.forEach(step => {
+        markdown += `- ${step.keyword.replace(/\*/g, "-")} ${step.text.replace(/</g, lt).replace(/>/g, gt)}\n`.replace("- -", "  -");
+        if (step.dataTable) {
+          markdown += '\n';
+          markdown += toTable(step.dataTable);
+          markdown += '\n';
+        }
+      });
+
+      if (element.examples) {
+        markdown += '\n';
+        markdown += toExamplesTable(element.examples);
+        markdown += '\n';
+      }
+
+      markdown += '\n';
+  return markdown;
+}
+
+function toRuleSection(element, tags) {
+  let markdown = '';
+  let elementTags = element.tags.map(tag => tag.name);
+  const matchingTags = elementTags.filter(tag => tags.includes(tag));
+  if (matchingTags.length === 0) {
+    return '';
+  }
+
+  markdown += `## ${element.keyword}: ${element.name}\n\n`;
+
+  if (element.elements && Array.isArray(element.elements)) {
+    element.elements.forEach(ruleElement => {
+
+      // Convert Regular Scenario
+      if (ruleElement.keyword === 'Scenario') {
+        markdown += toScenarioSection(ruleElement, tags);
+      }
+
+      // Convert Abstract Scenario
+      if (ruleElement.keyword === 'Abstract Scenario') {
+        markdown += toAbstractScenarioSection(ruleElement, tags);
+      }
+    });
+  }
+
+  return markdown;
+}
+
+function astToMarkdown(gherkinAST, tags) {
+  let markdown = '';
+
+  const feature = gherkinAST.feature;
+  markdown += `---\nlayout: page-with-side-nav\ntitle: ${feature.name}\n---\n\n`;
+  markdown += `# ${feature.keyword}: ${feature.name}\n\n`;
+
+  if (feature.description) {
+    markdown += `${feature.description}\n\n`;
+  }
+
+  if (feature.elements && Array.isArray(feature.elements)) {
+    feature.elements.forEach(element => {
+      if (element.keyword === 'Achtergrond') {
+        markdown += `## ${element.keyword}\n\n`;
+        element.steps.forEach(step => {
+          markdown += `- ${step.keyword.replace(/\*/g, "-")} ${step.text}\n`.replace("- -", "  -");
+          if (step.dataTable) {
+            markdown += '\n';
+            markdown += toTable(step.dataTable);
+            markdown += '\n';
+          }
+        });
+        markdown += '\n';
+      } else if (element.keyword === 'Regel') {
+        // Convert Rule
+        markdown += toRuleSection(element, tags);
+      }
+    });
+  }
+
+  return markdown;
+}
+
+async function convertGherkinToMarkdown(inputPath, outputPath, tags) {
+  try {
+    const featureFileContent = await fs.readFile(inputPath, 'utf8');
+    const document = await parse(featureFileContent, inputPath);
+    const gherkinAST = JSON.parse(JSON.stringify(document));
+    const markdownContent = astToMarkdown(gherkinAST, tags);
+
+    await fs.writeFile(outputPath, markdownContent);
+
+    console.log(`Markdown file generated successfully in ${outputPath}`);
+  } catch (error) {
+    console.error('Error converting Gherkin to Markdown:', error);
+  }
+}
+
+
+module.exports = { convertGherkinToMarkdown };

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -1,0 +1,90 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { convertGherkinToMarkdown } = require('./convert-feature-file');
+
+let tags = [];
+
+process.argv.forEach(function (val, index, array) {
+  if (index >= 4) {
+    tags.push(val.replace('@', ''));
+  }
+});
+
+async function processDirectory(inputDir, outputDir, tags) {
+  try {
+    await fs.mkdir(outputDir, { recursive: true });
+
+    const files = await fs.readdir(inputDir);
+    for (const file of files) {
+      const inputFilePath = path.join(inputDir, file);
+      const outputFilePath = path.join(outputDir, `${path.basename(file, '.feature')}.feature.md`);
+      if (path.extname(file) === '.feature') {
+        await convertGherkinToMarkdown(inputFilePath, outputFilePath, tags);
+      }
+    }
+  } catch (error) {
+    console.error('Error processing directory:', error);
+  }
+}
+
+async function main() {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3];
+
+  try {
+    const stats = await fs.stat(inputPath);
+    if (stats.isDirectory()) {
+      await processDirectory(inputPath, outputPath, tags);
+    } else if (stats.isFile()) {
+      await convertGherkinToMarkdown(inputPath, outputPath, tags);
+    } else {
+      console.error('Input path is neither a file nor a directory');
+    }
+  } catch (error) {
+    console.error('Error processing input path:', error);
+  }
+}
+
+main();
+
+/**
+ Losse bestanden converteren: (Let op: gebruik .md als output-file-path extensie)
+ node scripts/convert.js <input-file-path> <output-file-path> <...tags>
+  
+ Folders converteren:
+ node scripts/convert.js <input-directory-path> <output-directory-path> <...tags>
+  
+ Notes: 
+ - Scenario elementen moeten voorafgegaan worden door een Regel-element.
+ - Scenario elementen zonder een voorafgaand Regel-element worden genegeerd.
+ - Scenario elementen zonder een tag worden genegeerd.
+ - Regel elementen zonder een tag worden genegeerd.
+  
+ Voorbeeld:
+ ----------
+ Functionaliteit: Een omschrijving van de functionaliteit
+
+  @tag
+  Regel: De regel
+
+    @tag
+    Scenario: Een beschrijving van het scenario
+      Gegeven ...
+      En ...
+      Als ...
+      Dan ...
+ ----------
+
+ * Frontmatter is automatisch gegenereerd. De frontmatter bevat de volgende items:
+    - layout: page-with-side-nav
+    - title: <feature-name>
+
+ * De volgende Gherkin keywords worden ondersteund:
+    - Functionaliteit
+    - Achtergrond
+    - Feature
+    - Regel
+    - Scenario
+    - Abstract Scenario
+    - Voorbeelden
+ */


### PR DESCRIPTION
Functionaliteit toegevoegd om features om te kunnen zetten naar markdown. 

Kan zowel individuele bestanden als hele directories converteren.
Met tags kan ingesteld worden welke tagged scenario's geconverteerd moeten worden. 
Werkt voor reguliere scenario's en abstracte scenario's, bij abstracte scenario's worden de variabelen tussen <> als code element getoond.
Werkt alleen voor scenario's die een voorafgaand Regel element bevatten

Bijvoorbeeld:
\<waarde\> wordt in markdown omgezet naar `<waarde>`

Zie scripts/convert.js voor voorbeelden