### PR TITLE
specs: implementatie validatie van integratie docs en helpers

### DIFF
--- a/features/step_definitions/docs-stepdefs-integratie.js
+++ b/features/step_definitions/docs-stepdefs-integratie.js
@@ -1,0 +1,38 @@
+const { Given, When, Then } = require('@cucumber/cucumber');
+const { execute, truncate, select } = require('./postgresqlHelpers-2');
+const { generateSqlStatementsFrom } = require('./sqlStatementsFactory');
+const { assert } = require('chai');
+
+Given(/de tabel '(.*)' bevat geen rijen/, async function (tabelNaam) {
+    await truncate(tabelNaam);
+});
+
+
+When(/^de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd$/, async function () {
+    if(this.context.data) {
+        await execute(generateSqlStatementsFrom(this.context.data));
+    }
+});
+
+Then(/heeft de persoon '(.*)' de volgende rij in tabel '(.*)'/, async function(_, tabelNaam, dataTable) {    
+    let results = await select(tabelNaam, dataTable);
+
+    validateResult(results);
+});
+
+
+Then(/heeft de persoon '(.*)' de volgende rijen in tabel '(.*)'/, async function(_, tabelNaam, dataTable) {
+    let results = await select(tabelNaam, dataTable);
+    
+    validateResult(results);
+});
+
+function validateResult(results){
+    results.forEach(item => {
+        if(item.result.rows.length > 0) {
+            assert.containsAllKeys(item.result.rows[0], Object.keys(item.row));
+        }else{
+            throw {'Error': 'No matching records found!', 'Row': item.row}
+        }
+    })
+}


### PR DESCRIPTION
Dit PR introduceert de mogelijkheid om de integratie met een daadwerkelijke database te valideren:

De volgende operaties zijn geïmplementeerd:

`Gegeven de tabel '[tabel naam]' bevat geen rijen`
Dit statement truncate de tabel en zorgt ervoor dat het uitvoeren van de scenario's met daadwerkelijke records uit de database idempotent is.

`Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd`
Dit statement genereert de sql statements en voert ze uit. Na deze gegevenstap kunnen de gegevens worden gevalideerd.

`Dan heeft de persoon '[aanduiding] de volgende rij/rijen in tabel '[tabel naam]` gevolgd door een dataTable. 
Dit statement bouwt een select query op aan de hand van de genoemde kolommen en waarden in de datable.
Het aantal resultaten wordt vergeleken met het aantal rijen in de dataTable.
Note: Alleen kolommen die opgenomen zijn in de dataTable worden toegevoegd aan het filter in het te genereren SQL statement. Hiermee zorgen we er voor dat alleen relevante informatie opgenomen hoeft te worden in het scenario.

Voorbeeld:

```feature
Achtergrond:
  Gegeven de tabel 'lo3_pl' bevat geen rijen
  En de tabel 'lo3_pl_persoon' bevat geen rijen

 Scenario: de persoon met burgerservicenummer
  Gegeven de persoon 'Tosca' met burgerservicenummer '000000012'
  Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
  Dan heeft de persoon 'Tosca' de volgende rij in tabel 'lo3_pl'
    | pl_id | geheim_ind |
    |     1 |          0 |
  En heeft de persoon 'Tosca' de volgende rij in tabel 'lo3_pl_persoon'
    | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr |
    |     1 | P            |         0 |       0 |         000000012 | Tosca          |               6030 | 1AA0100 |
```

