### PR TITLE
persoon zonder burgerservicenummer' stap definities

### DIFF
--- a/features/docs/gegeven-stap-definities-ouder.feature
+++ b/features/docs/gegeven-stap-definities-ouder.feature
@@ -7,6 +7,27 @@ Functionaliteit: Ouder gegeven stap definities
     Gegeven de 1e 'SELECT COALESCE(MAX(adres_id), 0)+1 FROM public.lo3_adres' statement heeft als resultaat '4999'
     En de 1e 'SELECT COALESCE(MAX(pl_id), 0)+1 FROM public.lo3_pl' statement heeft als resultaat '9999'
 
+  @integratie
+  Abstract Scenario: heeft '[aanduiding]' als ouder [1 of 2]
+    Gegeven de persoon 'P2' zonder burgerservicenummer
+    En de persoon 'P1' met burgerservicenummer '000000036'
+    * heeft 'P2' als ouder <ouder type>
+    Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
+      | pl_id | geheim_ind |
+      |     1 |          0 |
+    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+      | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
+      |     1 |         0 |       0 |            P |         000000036 |             P1 |
+    En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+      | pl_id | stapel_nr | volg_nr | persoon_type | geslachts_naam |
+      |     1 |         0 |       0 | <ouder type> |             P2 |
+
+    Voorbeelden:
+      | ouder type |
+      |          1 |
+      |          2 |
+
   Abstract Scenario: de persoon met burgerservicenummer '[bsn]' heeft een ouder '[ouder-type]' met de volgende gegevens
     Gegeven de persoon met burgerservicenummer '000000012' heeft een ouder '<ouder-type>' met de volgende gegevens
     | naam                  | waarde |

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -8,8 +8,8 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
     En de 2e 'SELECT COALESCE(MAX(pl_id), 0)+1 FROM public.lo3_pl' statement heeft als resultaat '10000'
 
   @integratie
-  Scenario: persoon '[persoon aanduiding]' heeft de volgende gegevens
-    Gegeven persoon 'P1' heeft de volgende gegevens
+  Abstract Scenario: (de) persoon '[persoon aanduiding]' heeft de volgende gegevens
+    Gegeven <stap>
       | burgerservicenummer (01.20) | geslachtsnaam (02.40) |
       |                   000000012 | Jansen                |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
@@ -19,6 +19,25 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
       |     1 |         0 |       0 |            P |         000000012 |         Jansen |
+
+    Voorbeelden:
+      | stap                                       |
+      | persoon 'P1' heeft de volgende gegevens    |
+      | de persoon 'P1' heeft de volgende gegevens |
+
+  @integratie
+  Scenario: (de) persoon '[persoon aanduiding]' zonder burgerservicenummer heeft de volgende gegevens
+    Gegeven <stap>
+      | geslachtsnaam (02.40) |
+      | Jansen                |
+    Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+    Dan zijn er geen rijen in tabel 'lo3_pl'
+    En zijn er geen rijen in tabel 'lo3_pl_persoon'
+
+    Voorbeelden:
+      | stap                                                                  |
+      | persoon 'P1' zonder burgerservicenummer heeft de volgende gegevens    |
+      | de persoon 'P1' zonder burgerservicenummer heeft de volgende gegevens |
 
   Scenario: de persoon met burgerservicenummer '[bsn]' heeft de volgende gegevens
     Gegeven de persoon met burgerservicenummer '000000012' heeft de volgende gegevens

--- a/features/step_definitions/docs-stepdefs-integratie.js
+++ b/features/step_definitions/docs-stepdefs-integratie.js
@@ -1,7 +1,10 @@
 const { Given, When, Then } = require('@cucumber/cucumber');
+const { queryRowCount } = require('./postgresqlHelpers');
 const { execute, truncate, select } = require('./postgresqlHelpers-2');
 const { generateSqlStatementsFrom } = require('./sqlStatementsFactory');
 const { assert } = require('chai');
+const deepEqualInAnyOrder = require('deep-equal-in-any-order');
+const should = require('chai').use(deepEqualInAnyOrder).should();
 
 Given(/de tabel '(.*)' bevat geen rijen/, async function (tabelNaam) {
     await truncate(tabelNaam);
@@ -29,3 +32,10 @@ function validateResult(results){
         }
     })
 }
+
+Then(/^zijn er geen rijen in tabel '([a-z0-9_]*)'$/, async function (tabelNaam) {
+    const actual = await queryRowCount(global.pool, tabelNaam);
+
+    should.exist(actual);
+    actual.should.equal('0');
+});

--- a/features/step_definitions/gegeven-stepdefs-expressief.js
+++ b/features/step_definitions/gegeven-stepdefs-expressief.js
@@ -132,6 +132,10 @@ Given(/^(?:de persoon(?: '(.*)')? )?met burgerservicenummer '(\d*)'$/, function 
     gegevenDePersoonMetBsn(this.context, aanduiding, burgerservicenummer, undefined);
 });
 
+Given(/^(?:de persoon(?: '(.*)')? )?zonder burgerservicenummer$/, function (aanduiding) {
+    gegevenDePersoonMetBsn(this.context, aanduiding, undefined, undefined);
+});
+
 function wijzigPersoonContext(context, aanduiding) {
     const persoonId = `persoon-${aanduiding}`;
     const index = context.data.personen.findIndex(element => element.id === persoonId);

--- a/features/step_definitions/gegeven-stepdefs-expressief.js
+++ b/features/step_definitions/gegeven-stepdefs-expressief.js
@@ -122,7 +122,7 @@ function gegevenDePersoonMetBsn(context, aanduiding, burgerservicenummer, dataTa
     );
 }
 
-Given(/^(?:de )?persoon '([a-zA-Z0-9]*)' heeft de volgende gegevens$/, function (aanduiding, dataTable) {
+Given(/^(?:de )?persoon '([a-zA-Z0-9]*)'(?: zonder burgerservicenummer)? heeft de volgende gegevens$/, function (aanduiding, dataTable) {
     gegevenDePersoonMetBsn(this.context, aanduiding, undefined, dataTable);
 
     global.logger.info(`gegeven persoon '${aanduiding}'`, getPersoon(this.context, aanduiding));

--- a/features/step_definitions/sqlStatementsFactory.js
+++ b/features/step_definitions/sqlStatementsFactory.js
@@ -116,6 +116,10 @@ function generateAdresSqlStatements(adressen) {
     return sqlStatements;
 }
 
+function getBsn(persoon) {
+    return persoon.persoon.at(-1).burger_service_nr;
+}
+
 function generateSqlStatementsFrom(data) {
     if(!data) {
         global.logger.warn('no data to generate sql statements');
@@ -133,27 +137,32 @@ function generateSqlStatementsFrom(data) {
             statements: []
         };
 
-        Object.keys(persoon).forEach(key => {
-            let statement;
-            switch(key) {
-                case 'id':
-                    break;
-                case 'inschrijving':
-                    statement = createInsertIntoPersoonslijstStatement(persoon.inschrijving);
-                    break;
-                default:
-                    persoon[key].forEach(p => {
-                        persoonStatements.statements.push(createInsertIntoStatement(key, p));
-                    });
-                    break;
-            }
+        if(getBsn(persoon) === undefined) {
+            global.logger.info('persoon zonder burgerservicenummer. Geen sql statements generatie', persoon);
+        }
+        else {
+            Object.keys(persoon).forEach(key => {
+                let statement;
+                switch(key) {
+                    case 'id':
+                        break;
+                    case 'inschrijving':
+                        statement = createInsertIntoPersoonslijstStatement(persoon.inschrijving);
+                        break;
+                    default:
+                        persoon[key].forEach(p => {
+                            persoonStatements.statements.push(createInsertIntoStatement(key, p));
+                        });
+                        break;
+                }
 
-            if(statement) {
-                persoonStatements.statements.push(statement);
-            }
-        });
+                if(statement) {
+                    persoonStatements.statements.push(statement);
+                }
+            });
 
-        sqlStatements.personen.push(persoonStatements);
+            sqlStatements.personen.push(persoonStatements);
+        }
     });
 
     return sqlStatements;


### PR DESCRIPTION
om aan te kunnen geven dat een persoon zonder ouder is van een ander persoon is de stap definitie 'persoon '[aanduiding]' zonder burgerservicenummer heeft de volgende gegevens' toegevoegd. Voor personen zonder burgerservicenummer worden geen sql statements gegenereerd zodat er voor hun geen persoonslijst wordt aangemaakt