### PR TITLE
chore(automation): @nieuw tag toegevoegd + gecorrigeerde profielen

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -37,7 +37,7 @@ module.exports = {
       },
       addAcceptGezagVersionHeader: false
     },
-    tags: '@deprecated and ((not @gezag-api and not @data-api) or @info-api)'
+    tags: 'not @skip-verify and ((@deprecated and ((not @data-api and not @gezag-api) or @info-api)) or (not @deprecated and not @nieuw and ((not @data-api and not @gezag-api) or @info-api)))'
   },
   DataApi: {
     worldParameters: {
@@ -55,11 +55,11 @@ module.exports = {
       apiUrl: 'http://localhost:8000/haalcentraal/api',
       api: 'data-api',
       logger: {
-        level: 'info'
+        level: 'warn'
       },
       addAcceptGezagVersionHeader: false
     },
-    tags: '@deprecated and ((not @gezag-api and not @info-api) or @data-api)'
+    tags: 'not @skip-verify and ((@deprecated and ((not @gezag-api and not @info-api) or @data-api)) or (not @deprecated and not @nieuw and ((not @gezag-api and not @info-api) or @data-api)))'
   },
   GezagApi: {
     worldParameters: {
@@ -81,6 +81,6 @@ module.exports = {
       },
       addAcceptGezagVersionHeader: false
     },
-    tags: '@deprecated and ((not @data-api and not @info-api) or @gezag-api)'
+    tags: 'not @skip-verify and ((@deprecated and ((not @data-api and not @info-api) or @gezag-api)) or (not @deprecated and not @nieuw and ((not @data-api and not @info-api) or @gezag-api)))'
   }
 }

--- a/features/docs/profielen.feature
+++ b/features/docs/profielen.feature
@@ -1,7 +1,7 @@
 #language: nl
 Functionaliteit: profielen
 
-  Regel: scenarios die gelden voor alle apis
+  Regel: bestaande scenarios die niet zijn gewijzigd
 
     Scenario: scenario die voor alle profielen moet worden uitgevoerd
 
@@ -41,6 +41,6 @@ Functionaliteit: profielen
 
     @data-api
     Scenario: deprecated scenario die voor DataApiDeprecated profiel moet worden uitgevoerd
-    
+
     @gezag-api
     Scenario: deprecated scenario die voor GezagApiDeprecated profiel moet worden uitgevoerd

--- a/features/docs/profielen.feature
+++ b/features/docs/profielen.feature
@@ -1,0 +1,46 @@
+#language: nl
+Functionaliteit: profielen
+
+  Regel: scenarios die gelden voor alle apis
+
+    Scenario: scenario die voor alle profielen moet worden uitgevoerd
+
+    @info-api
+    Scenario: scenario die voor InfoApi en InfoApiDeprecated profielen moet worden uitgevoerd
+
+    @data-api
+    Scenario: scenario die voor DataApi en DataApiDeprecated profielen moet worden uitgevoerd
+
+    @gezag-api
+    Scenario: scenario die voor GezagApi en GezagApiDeprecated profielen moet worden uitgevoerd
+
+    @skip-verify
+    Scenario: scenario die voor geen enkel profiel moet worden uitgevoerd
+
+  @nieuw
+  Regel: nieuwe scenarios
+
+    Scenario: nieuwe scenario die voor InfoApi, DataApi en GezagApi profielen moet worden uitgevoerd
+
+    @info-api
+    Scenario: nieuwe scenario die voor InfoApi profiel moet worden uitgevoerd
+
+    @data-api
+    Scenario: nieuwe scenario die voor DataApi profiel moet worden uitgevoerd
+
+    @gezag-api
+    Scenario: nieuwe scenario die voor GezagApi profiel moet worden uitgevoerd
+
+  @deprecated
+  Regel: deprecated scenarios
+
+    Scenario: deprecated scenario die voor InfoApiDeprecated, DataApiDeprecated en GezagApiDeprecated profielen moet worden uitgevoerd
+
+    @info-api
+    Scenario: deprecated scenario die voor InfoApiDeprecated profiel moet worden uitgevoerd
+
+    @data-api
+    Scenario: deprecated scenario die voor DataApiDeprecated profiel moet worden uitgevoerd
+    
+    @gezag-api
+    Scenario: deprecated scenario die voor GezagApiDeprecated profiel moet worden uitgevoerd

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -63,6 +63,8 @@ Before(function({ pickle }) {
     this.context.isInfoApiAanroep = this.context.parameters.api === 'info-api';
     this.context.isDataApiAanroep = this.context.parameters.api === 'data-api';
     this.context.isGezagApiAanroep = this.context.parameters.api === 'gezag-api';
+
+    global.logger.info(`scenario '${pickle.name}' met tags ${JSON.stringify(tags)}`);
 });
 
 After(async function() {


### PR DESCRIPTION
@nieuw tag opgenomen in de cucumber profielen om de volgende situatien te ondersteunen:

uit te voeren scenarios bij GezagApi profiel:
- scenario die voor alle profielen moet worden uitgevoerd
- scenario die voor GezagApi en GezagApiDeprecated profielen moet worden uitgevoerd
- nieuwe scenario die voor InfoApi, DataApi en GezagApi profielen moet worden uitgevoerd
- nieuwe scenario die voor GezagApi profiel moet worden uitgevoerd

uit te voeren scenario's bij GezagApiDeprecated profiel:
- scenario die voor alle profielen moet worden uitgevoerd
- scenario die voor GezagApi en GezagApiDeprecated profielen moet worden uitgevoerd
- deprecated scenario die voor InfoApi, DataApi en GezagApi profielen moet worden uitgevoerd
- deprecated scenario die voor GezagApi profiel moet worden uitgevoerd

Hetzelfde geldt ook voor de info/data profielen

De profielen feature is toegevoegd om dit te valideren. Wanneer deze feature wordt uitgevoerd met een profiel moet in de betreffende profiel de loglevel op info worden gezet