### PR TITLE
refactor: primary key value bepalen met aanduiding

### DIFF
--- a/features/docs/gegeven-stap-definities-adres.feature
+++ b/features/docs/gegeven-stap-definities-adres.feature
@@ -1,5 +1,5 @@
 # language: nl
-@integratie @stap-documentatie
+@stap-documentatie
 Functionaliteit: Adres gegeven stap definities
 
   Achtergrond:
@@ -15,7 +15,7 @@ Functionaliteit: Adres gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de adres 'A1' de volgende rij in tabel 'lo3_adres'
       | adres_id | gemeente_code |
-      |        1 |          0518 |
+      |       A1 |          0518 |
 
   @integratie
   Scenario: adres '[adres aanduiding]' (meerdere adressen)
@@ -28,10 +28,10 @@ Functionaliteit: Adres gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de adres 'A1' de volgende rij in tabel 'lo3_adres'
       | adres_id | gemeente_code |
-      |        1 |          0518 |
+      |       A1 |          0518 |
     En heeft de adres 'A2' de volgende rij in tabel 'lo3_adres'
       | adres_id | gemeente_code | verblijf_plaats_ident_code |
-      |        2 |          0800 |           0800010011067001 |
+      |       A2 |          0800 |           0800010011067001 |
 
   Scenario: adres '[identificatie]' heeft de volgende gegevens
     Gegeven adres 'A1' heeft de volgende gegevens

--- a/features/docs/gegeven-stap-definities-adres.feature
+++ b/features/docs/gegeven-stap-definities-adres.feature
@@ -13,7 +13,7 @@ Functionaliteit: Adres gegeven stap definities
       | gemeentecode (92.10) |
       |                 0518 |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de adres 'A1' de volgende rij in tabel 'lo3_adres'
+    Dan heeft adres 'A1' de volgende rij in tabel 'lo3_adres'
       | adres_id | gemeente_code |
       |       A1 |          0518 |
 
@@ -26,10 +26,10 @@ Functionaliteit: Adres gegeven stap definities
       | gemeentecode (92.10) | identificatiecode verblijfplaats (11.80) |
       |                 0800 |                         0800010011067001 |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de adres 'A1' de volgende rij in tabel 'lo3_adres'
+    Dan heeft adres 'A1' de volgende rij in tabel 'lo3_adres'
       | adres_id | gemeente_code |
       |       A1 |          0518 |
-    En heeft de adres 'A2' de volgende rij in tabel 'lo3_adres'
+    En heeft adres 'A2' de volgende rij in tabel 'lo3_adres'
       | adres_id | gemeente_code | verblijf_plaats_ident_code |
       |       A2 |          0800 |           0800010011067001 |
 

--- a/features/docs/gegeven-stap-definities-geboorte.feature
+++ b/features/docs/gegeven-stap-definities-geboorte.feature
@@ -6,10 +6,10 @@ Functionaliteit: Geboorte gegeven stap definities
     Gegeven de persoon 'Jansen' met burgerservicenummer '000000012'
     * is <datum> geboren
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'Jansen' de volgende rij in tabel 'lo3_pl'
+    Dan heeft persoon 'Jansen' de volgende rij in tabel 'lo3_pl'
       | pl_id  | geheim_ind |
       | Jansen |          0 |
-    Dan heeft de persoon 'Jansen' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'Jansen' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id  | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam | geboorte_datum     |
       | Jansen |         0 |       0 | P            |         000000012 | Jansen         | <yyyymmdd formaat> |
 

--- a/features/docs/gegeven-stap-definities-geboorte.feature
+++ b/features/docs/gegeven-stap-definities-geboorte.feature
@@ -6,12 +6,12 @@ Functionaliteit: Geboorte gegeven stap definities
     Gegeven de persoon 'Jansen' met burgerservicenummer '000000012'
     * is <datum> geboren
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
-      | pl_id | geheim_ind |
-      |     1 |          0 |
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
-      | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam | geboorte_datum     |
-      |     1 |         0 |       0 | P            |         000000012 | Jansen         | <yyyymmdd formaat> |
+    Dan heeft de persoon 'Jansen' de volgende rij in tabel 'lo3_pl'
+      | pl_id  | geheim_ind |
+      | Jansen |          0 |
+    Dan heeft de persoon 'Jansen' de volgende rij in tabel 'lo3_pl_persoon'
+      | pl_id  | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam | geboorte_datum     |
+      | Jansen |         0 |       0 | P            |         000000012 | Jansen         | <yyyymmdd formaat> |
 
     Voorbeelden:
       | datum                  | yyyymmdd formaat       |

--- a/features/docs/gegeven-stap-definities-gezag-expressief.feature
+++ b/features/docs/gegeven-stap-definities-gezag-expressief.feature
@@ -2,27 +2,21 @@
 @integratie @stap-documentatie
 Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
 
-  Achtergrond:
-    Gegeven de tabel 'lo3_pl' bevat geen rijen
-    En de tabel 'lo3_pl_persoon' bevat geen rijen
-
   Regel: Een persoon benoemen we functioneel met een naam en technisch met een burgerservicenummer
     Standaard is een persoon in Nederland geboren met een Nederlandse geboorteakte.
 
-    @integratie
     Scenario: de persoon '{naam}' met burgerservicenummer '{bsn}'
       Gegeven de persoon 'P1' heeft de volgende gegevens
         | burgerservicenummer (01.20) | geslachtsnaam (02.40) |
-        |                   000000012 | P1                 |
+        |                   000000012 | P1                    |
       Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
       Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
         | pl_id | geheim_ind |
-        |     1 |          0 |
+        |    P1 |          0 |
       En heeft de persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam |
-        |     1 | P            |         0 |       0 |         000000012 | P1          |
+        |    P1 | P            |         0 |       0 |         000000012 | P1             |
 
-    @integratie
     Scenario: '{naam}' is minderjarig
       Gegeven de persoon 'P2' heeft de volgende gegevens
         | burgerservicenummer (01.20) | geslachtsnaam (02.40) |
@@ -35,13 +29,13 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
       Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
       Dan heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl'
         | pl_id | geheim_ind |
-        |     2 |          0 |
+        |    P2 |          0 |
       En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_datum     |
-        |     2 | P            |         0 |       0 |         000000012 | P2             | gisteren - 17 jaar |
+        |    P2 | P            |         0 |       0 |         000000012 | P2             | gisteren - 17 jaar |
       En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
         | pl_id | geheim_ind |
-        |     1 |          0 |
+        |    P1 |          0 |
       En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam |
-        |     1 | P            |         0 |       0 |         000000024 | P1             |
+        |    P1 | P            |         0 |       0 |         000000024 | P1             |

--- a/features/docs/gegeven-stap-definities-gezag-expressief.feature
+++ b/features/docs/gegeven-stap-definities-gezag-expressief.feature
@@ -10,10 +10,10 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         | burgerservicenummer (01.20) | geslachtsnaam (02.40) |
         |                   000000012 | P1                    |
       Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-      Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
+      Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
         | pl_id | geheim_ind |
         |    P1 |          0 |
-      En heeft de persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
+      En heeft persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam |
         |    P1 | P            |         0 |       0 |         000000012 | P1             |
 
@@ -27,15 +27,15 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
       En persoon 'P2'
       * is minderjarig
       Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-      Dan heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl'
+      Dan heeft persoon 'P2' de volgende rij in tabel 'lo3_pl'
         | pl_id | geheim_ind |
         |    P2 |          0 |
-      En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+      En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_datum     |
         |    P2 | P            |         0 |       0 |         000000012 | P2             | gisteren - 17 jaar |
-      En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
+      En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
         | pl_id | geheim_ind |
         |    P1 |          0 |
-      En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+      En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam |
         |    P1 | P            |         0 |       0 |         000000024 | P1             |

--- a/features/docs/gegeven-stap-definities-ouder.feature
+++ b/features/docs/gegeven-stap-definities-ouder.feature
@@ -15,13 +15,13 @@ Functionaliteit: Ouder gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
       | pl_id | geheim_ind |
-      |     1 |          0 |
+      |    P1 |          0 |
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
-      |     1 |         0 |       0 |            P |         000000036 |             P1 |
+      |    P1 |         0 |       0 |            P |         000000036 |             P1 |
     En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | geslachts_naam |
-      |     1 |         0 |       0 | <ouder type> |             P2 |
+      |    P1 |         0 |       0 | <ouder type> |             P2 |
 
     Voorbeelden:
       | ouder type |

--- a/features/docs/gegeven-stap-definities-ouder.feature
+++ b/features/docs/gegeven-stap-definities-ouder.feature
@@ -13,13 +13,13 @@ Functionaliteit: Ouder gegeven stap definities
     En de persoon 'P1' met burgerservicenummer '000000036'
     * heeft 'P2' als ouder <ouder type>
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
       | pl_id | geheim_ind |
       |    P1 |          0 |
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
       |    P1 |         0 |       0 |            P |         000000036 |             P1 |
-    En heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | geslachts_naam |
       |    P1 |         0 |       0 | <ouder type> |             P2 |
 

--- a/features/docs/gegeven-stap-definities-partner.feature
+++ b/features/docs/gegeven-stap-definities-partner.feature
@@ -1,11 +1,9 @@
 # language: nl
-
-@integratie @stap-documentatie
+@stap-documentatie
 Functionaliteit: Partner gegeven stap definities
 
   Achtergrond:
     Gegeven de 1e 'SELECT COALESCE(MAX(pl_id), 0)+1 FROM public.lo3_pl' statement heeft als resultaat '9999'
-    En de tabel 'lo3_pl_persoon' bevat geen rijen
 
   Scenario: de persoon met burgerservicenummer '[bsn]' heeft een 'partner' met de volgende gegevens
     Gegeven de persoon met burgerservicenummer '000000012' heeft een 'partner' met de volgende gegevens
@@ -71,10 +69,10 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
-      |     1 | R            |         0 |       0 |         000000024 | P2             | gisteren - 20 jaar  |                 0518 |                    6030 |
+      |    P1 | R            |         0 |       0 |         000000024 | P2             | gisteren - 20 jaar  |                 0518 |                    6030 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
-      |     2 | R            |         0 |       0 |         000000012 | P1             | gisteren - 20 jaar  |                 0518 |                    6030 |
+      |    P2 | R            |         0 |       0 |         000000012 | P1             | gisteren - 20 jaar  |                 0518 |                    6030 |
 
   @integratie
   Scenario: personen zijn met elkaar gehuwd met de volgende gegevens
@@ -90,10 +88,10 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum |
-      |     1 | R            |         0 |       0 |         000000024 | P2             |            20100401 |
+      |    P1 | R            |         0 |       0 |         000000024 | P2             |            20100401 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum |
-      |     2 | R            |         0 |       0 |         000000012 | P1             |            20100401 |
+      |    P2 | R            |         0 |       0 |         000000012 | P1             |            20100401 |
 
   @integratie
   Scenario: personen zijn gescheiden
@@ -108,16 +106,16 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
-      |     1 | R            |         0 |       1 |         000000024 | P2             | gisteren - 20 jaar  |                 0518 |                    6030 |
+      |    P1 | R            |         0 |       1 |         000000024 | P2             | gisteren - 20 jaar  |                 0518 |                    6030 |
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code |
-      |     1 | R            |         0 |       0 |         000000024 | P2             | gisteren - 1 jaar  |                0518 |                   6030 |
+      |    P1 | R            |         0 |       0 |         000000024 | P2             | gisteren - 1 jaar  |                0518 |                   6030 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
-      |     2 | R            |         0 |       1 |         000000012 | P1             | gisteren - 20 jaar  |                 0518 |                    6030 |
+      |    P2 | R            |         0 |       1 |         000000012 | P1             | gisteren - 20 jaar  |                 0518 |                    6030 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code |
-      |     2 | R            |         0 |       0 |         000000012 | P1             | gisteren - 1 jaar  |                0518 |                   6030 |
+      |    P2 | R            |         0 |       0 |         000000012 | P1             | gisteren - 1 jaar  |                0518 |                   6030 |
 
   @integratie
   Scenario: personen zijn gescheiden met de volgende gegevens
@@ -134,10 +132,10 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum |
-      |     1 | R            |         0 |       0 |         000000024 | P2             |           20101231 |
+      |    P1 | R            |         0 |       0 |         000000024 | P2             |           20101231 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum |
-      |     2 | R            |         0 |       0 |         000000012 | P1             |           20101231 |
+      |    P2 | R            |         0 |       0 |         000000012 | P1             |           20101231 |
 
   @integratie
   Scenario: persoon heeft partner en ex-partner
@@ -160,14 +158,14 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum | relatie_start_datum |
-      |     1 | R            |         0 |       0 |         000000024 | P2             |           20101231 |                     |
-      |     1 | R            |         1 |       0 |         000000036 | P3             |                    |            20240101 |
+      |    P1 | R            |         0 |       0 |         000000024 | P2             |           20101231 |                     |
+      |    P1 | R            |         1 |       0 |         000000036 | P3             |                    |            20240101 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum |
-      |     2 | R            |         0 |       0 |         000000012 | P1             |           20101231 |
+      |    P2 | R            |         0 |       0 |         000000012 | P1             |           20101231 |
     En heeft de persoon 'P3' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum |
-      |     3 | R            |         0 |       0 |         000000012 | P1             |            20240101 |
+      |    P3 | R            |         0 |       0 |         000000012 | P1             |            20240101 |
 
   @integratie
   Scenario: personen zijn op een relatieve datum een geregistreerd partnerschap aangegaan
@@ -181,10 +179,10 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | verbintenis_soort |
-      |     1 | R            |         0 |       0 |         000000024 | P2             |                    |         |      7 jaar geleden |                 0518 |                    6030 | P                 |
+      |    P1 | R            |         0 |       0 |         000000024 | P2             |                    |         |      7 jaar geleden |                 0518 |                    6030 | P                 |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | verbintenis_soort |
-      |     2 | R            |         0 |       0 |         000000012 | P1             |                    |         |      7 jaar geleden |                 0518 |                    6030 | P                 |
+      |    P2 | R            |         0 |       0 |         000000012 | P1             |                    |         |      7 jaar geleden |                 0518 |                    6030 | P                 |
 
   @integratie
   Scenario: huwelijk gecorrigeerd als nietig
@@ -208,10 +206,9 @@ Functionaliteit: Partner gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | onjuist_ind | geldigheid_start_datum |
-      |     1 | R            |         0 |       1 |         000000024 | P2             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 | O           |                        |
-      |     1 | R            |         0 |       0 |                   |                |                    |         |                     |                      |                         |             |         2 jaar geleden |
+      |    P1 | R            |         0 |       1 |         000000024 | P2             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 | O           |                        |
+      |    P1 | R            |         0 |       0 |                   |                |                    |         |                     |                      |                         |             |         2 jaar geleden |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | onjuist_ind | geldigheid_start_datum |
-      |     2 | R            |         0 |       1 |         000000012 | P1             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 | O           |                        |
-      |     2 | R            |         0 |       0 |                   |                |                    |         |                     |                      |                         |             |         2 jaar geleden |
-       
+      |    P2 | R            |         0 |       1 |         000000012 | P1             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 | O           |                        |
+      |    P2 | R            |         0 |       0 |                   |                |                    |         |                     |                      |                         |             |         2 jaar geleden |

--- a/features/docs/gegeven-stap-definities-partner.feature
+++ b/features/docs/gegeven-stap-definities-partner.feature
@@ -67,10 +67,10 @@ Functionaliteit: Partner gegeven stap definities
       |                   000000024 | P2                    |
     En 'P1' en 'P2' zijn met elkaar gehuwd
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
       |    P1 | R            |         0 |       0 |         000000024 | P2             | gisteren - 20 jaar  |                 0518 |                    6030 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
       |    P2 | R            |         0 |       0 |         000000012 | P1             | gisteren - 20 jaar  |                 0518 |                    6030 |
 
@@ -86,10 +86,10 @@ Functionaliteit: Partner gegeven stap definities
       | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
       |                                                           20100401 |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum |
       |    P1 | R            |         0 |       0 |         000000024 | P2             |            20100401 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum |
       |    P2 | R            |         0 |       0 |         000000012 | P1             |            20100401 |
 
@@ -104,16 +104,16 @@ Functionaliteit: Partner gegeven stap definities
     En 'P1' en 'P2' zijn met elkaar gehuwd
     En 'P1' en 'P2' zijn gescheiden
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
       |    P1 | R            |         0 |       1 |         000000024 | P2             | gisteren - 20 jaar  |                 0518 |                    6030 |
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code |
       |    P1 | R            |         0 |       0 |         000000024 | P2             | gisteren - 1 jaar  |                0518 |                   6030 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum | relatie_start_plaats | relatie_start_land_code |
       |    P2 | R            |         0 |       1 |         000000012 | P1             | gisteren - 20 jaar  |                 0518 |                    6030 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code |
       |    P2 | R            |         0 |       0 |         000000012 | P1             | gisteren - 1 jaar  |                0518 |                   6030 |
 
@@ -130,10 +130,10 @@ Functionaliteit: Partner gegeven stap definities
       | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) |
       |                                                     20101231 |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum |
       |    P1 | R            |         0 |       0 |         000000024 | P2             |           20101231 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum |
       |    P2 | R            |         0 |       0 |         000000012 | P1             |           20101231 |
 
@@ -156,14 +156,14 @@ Functionaliteit: Partner gegeven stap definities
       | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
       |                                                           20240101 |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum | relatie_start_datum |
       |    P1 | R            |         0 |       0 |         000000024 | P2             |           20101231 |                     |
       |    P1 | R            |         1 |       0 |         000000036 | P3             |                    |            20240101 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_eind_datum |
       |    P2 | R            |         0 |       0 |         000000012 | P1             |           20101231 |
-    En heeft de persoon 'P3' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P3' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | relatie_start_datum |
       |    P3 | R            |         0 |       0 |         000000012 | P1             |            20240101 |
 
@@ -177,10 +177,10 @@ Functionaliteit: Partner gegeven stap definities
       |                   000000024 | P2                    |
     En 'P1' en 'P2' zijn 7 jaar geleden een geregistreerd partnerschap aangegaan
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | verbintenis_soort |
       |    P1 | R            |         0 |       0 |         000000024 | P2             |                    |         |      7 jaar geleden |                 0518 |                    6030 | P                 |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | verbintenis_soort |
       |    P2 | R            |         0 |       0 |         000000012 | P1             |                    |         |      7 jaar geleden |                 0518 |                    6030 | P                 |
 
@@ -204,11 +204,11 @@ Functionaliteit: Partner gegeven stap definities
       | land huwelijkssluiting/aangaan geregistreerd partnerschap (06.30)   |                |
       | datum ingang geldigheid (85.10)                                     | 2 jaar geleden |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | onjuist_ind | geldigheid_start_datum |
       |    P1 | R            |         0 |       1 |         000000024 | P2             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 | O           |                        |
       |    P1 | R            |         0 |       0 |                   |                |                    |         |                     |                      |                         |             |         2 jaar geleden |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | onjuist_ind | geldigheid_start_datum |
       |    P2 | R            |         0 |       1 |         000000012 | P1             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 | O           |                        |
       |    P2 | R            |         0 |       0 |                   |                |                    |         |                     |                      |                         |             |         2 jaar geleden |

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -1,5 +1,4 @@
-#language: nl
-
+# language: nl
 @stap-documentatie
 Functionaliteit: Persoon, Inschrijving gegeven stap definities
 
@@ -15,10 +14,10 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
       | pl_id | geheim_ind |
-      |     1 |          0 |
+      |    P1 |          0 |
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
-      |     1 |         0 |       0 |            P |         000000012 |         Jansen |
+      |    P1 |         0 |       0 |            P |         000000012 |         Jansen |
 
     Voorbeelden:
       | stap                                       |

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -12,10 +12,10 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
       | burgerservicenummer (01.20) | geslachtsnaam (02.40) |
       |                   000000012 | Jansen                |
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
       | pl_id | geheim_ind |
       |    P1 |          0 |
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+    En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
       |    P1 |         0 |       0 |            P |         000000012 |         Jansen |
 

--- a/features/docs/gegeven-stap-definities-verblijfplaats.feature
+++ b/features/docs/gegeven-stap-definities-verblijfplaats.feature
@@ -23,7 +23,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
       |                   000000012 | Jansen                |
     * is ingeschreven in de BRP
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | volg_nr | inschrijving_gemeente_code |
       |    P1 |       0 |                       0518 |
 
@@ -34,7 +34,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
       |                   000000012 | Jansen                |
     * is niet ingeschreven in de BRP
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | volg_nr | inschrijving_gemeente_code |
       |    P1 |       0 |                       1999 |
 
@@ -48,7 +48,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
       |                   000000012 | Jansen                |
     En <stap>
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
       |    P1 |       A1 |       0 | W             | <datum>                  |
 
@@ -78,10 +78,10 @@ Functionaliteit: Verblijfplaats gegeven stap definities
       |                   000000024 | Albers                |
     En <stap>
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
       |    P1 |       A1 |       0 | W             | <datum>                  |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
       |    P2 |       A1 |       0 | W             | <datum>                  |
 
@@ -107,7 +107,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
       |                   000000012 | Jansen                |
     En <stap>
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
       |    P1 |       A1 |       0 | W             | <datum>                  |
 
@@ -132,10 +132,10 @@ Functionaliteit: Verblijfplaats gegeven stap definities
       |                   000000024 | Albers                |
     En <stap>
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
-    Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
       |    P1 |       A1 |       0 | W             | <datum>                  |
-    En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+    En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
       |    P2 |       A1 |       0 | W             | <datum>                  |
 

--- a/features/docs/gegeven-stap-definities-verblijfplaats.feature
+++ b/features/docs/gegeven-stap-definities-verblijfplaats.feature
@@ -25,7 +25,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | volg_nr | inschrijving_gemeente_code |
-      |     1 |       0 |                       0518 |
+      |    P1 |       0 |                       0518 |
 
   @integratie
   Scenario: is niet ingeschreven in de BRP
@@ -36,7 +36,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | volg_nr | inschrijving_gemeente_code |
-      |     1 |       0 |                       1999 |
+      |    P1 |       0 |                       1999 |
 
   @integratie
   Abstract Scenario: persoon '[persoon aanduiding]' is ingeschreven op adres '[adres aanduiding]' op [<datum type>]
@@ -50,7 +50,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
-      |     1 |        1 |       0 | W             | <datum>                  |
+      |    P1 |       A1 |       0 | W             | <datum>                  |
 
     Voorbeelden:
       | stap                                                              | datum    | datum type                 |
@@ -80,10 +80,10 @@ Functionaliteit: Verblijfplaats gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
-      |     1 |        1 |       0 | W             | <datum>                  |
+      |    P1 |       A1 |       0 | W             | <datum>                  |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
-      |     2 |        1 |       0 | W             | <datum>                  |
+      |    P2 |       A1 |       0 | W             | <datum>                  |
 
     Voorbeelden:
       | stap                                                               | datum    | datum type                 |
@@ -109,7 +109,7 @@ Functionaliteit: Verblijfplaats gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
-      |     1 |        1 |       0 | W             | <datum>                  |
+      |    P1 |       A1 |       0 | W             | <datum>                  |
 
     Voorbeelden:
       | stap                                                       | datum             |
@@ -134,10 +134,10 @@ Functionaliteit: Verblijfplaats gegeven stap definities
     Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
     Dan heeft de persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
-      |     1 |        1 |       0 | W             | <datum>                  |
+      |    P1 |       A1 |       0 | W             | <datum>                  |
     En heeft de persoon 'P2' de volgende rij in tabel 'lo3_pl_verblijfplaats'
       | pl_id | adres_id | volg_nr | adres_functie | adreshouding_start_datum |
-      |     2 |        1 |       0 | W             | <datum>                  |
+      |    P2 |       A1 |       0 | W             | <datum>                  |
 
     Voorbeelden:
       | stap                                                                       | datum             |

--- a/features/step_definitions/docs-stepdefs-integratie.js
+++ b/features/step_definitions/docs-stepdefs-integratie.js
@@ -1,24 +1,58 @@
 const { Given, When, Then } = require('@cucumber/cucumber');
 const { queryRowCount } = require('./postgresqlHelpers');
-const { execute, truncate, select } = require('./postgresqlHelpers-2');
+const { execute, select } = require('./postgresqlHelpers-2');
 const { generateSqlStatementsFrom } = require('./sqlStatementsFactory');
 const { assert } = require('chai');
 const deepEqualInAnyOrder = require('deep-equal-in-any-order');
 const should = require('chai').use(deepEqualInAnyOrder).should();
-
-Given(/de tabel '(.*)' bevat geen rijen/, async function (tabelNaam) {
-    await truncate(tabelNaam);
-});
+const { createObjectArrayFrom } = require('./dataTable2Object');
 
 
 When(/^de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd$/, async function () {
     if(this.context.data) {
-        await execute(generateSqlStatementsFrom(this.context.data));
+        const sqlStatements = generateSqlStatementsFrom(this.context.data);
+
+        this.context.aantalRijen = {
+            'lo3_pl': await queryRowCount(global.pool, 'inschrijving'),
+            'lo3_pl_persoon': await queryRowCount(global.pool, 'persoon')
+        }
+
+        await execute(sqlStatements);
+
+        for(const adres of sqlStatements.adressen) {
+            let input = this.context.data.adressen.find(a => a.id === adres.stap);
+            if(input) {
+                input.adresId = adres.adresId;
+            }
+        }
+        for(const persoon of sqlStatements.personen) {
+            let input = this.context.data.personen.find(p => p.id === persoon.stap);
+            if(input) {
+                input.plId = persoon.plId;
+            }
+        }
     }
 });
 
-Then(/heeft de (?:[a-z]*) '(.*)' de volgende rij(?:en)? in tabel '(.*)'/, async function(_, tabelNaam, dataTable) {    
-    let results = await select(tabelNaam, dataTable);
+Then(/heeft de ([a-z]*) '(.*)' de volgende rij(?:en)? in tabel '(.*)'/, async function(type, aanduiding, tabelNaam, dataTable) {
+    const objecten = createObjectArrayFrom(dataTable);
+
+    objecten.forEach(item => {
+        if(item.adres_id) {
+            const src = this.context.data.adressen.find(a => a.id === `adres-${item.adres_id}`);
+            if(src) {
+                item.adres_id = src.adresId;
+            }
+        }
+        if(item.pl_id) {
+            const src = this.context.data.personen.find(p => p.id === `persoon-${item.pl_id}`);
+            if(src) {
+                item.pl_id = src.plId;
+            }
+        }
+    });
+
+    const results = await select(tabelNaam, objecten);
 
     validateResult(results);
 });
@@ -37,5 +71,5 @@ Then(/^zijn er geen rijen in tabel '([a-z0-9_]*)'$/, async function (tabelNaam) 
     const actual = await queryRowCount(global.pool, tabelNaam);
 
     should.exist(actual);
-    actual.should.equal('0');
+    actual.should.equal(this.context.aantalRijen[tabelNaam]);
 });

--- a/features/step_definitions/docs-stepdefs-integratie.js
+++ b/features/step_definitions/docs-stepdefs-integratie.js
@@ -34,7 +34,7 @@ When(/^de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd$/, a
     }
 });
 
-Then(/heeft de ([a-z]*) '(.*)' de volgende rij(?:en)? in tabel '(.*)'/, async function(type, aanduiding, tabelNaam, dataTable) {
+Then(/heeft ([a-z]*) '(.*)' de volgende rij(?:en)? in tabel '(.*)'/, async function(type, aanduiding, tabelNaam, dataTable) {
     const objecten = createObjectArrayFrom(dataTable);
 
     objecten.forEach(item => {

--- a/features/step_definitions/postgresqlHelpers-2.js
+++ b/features/step_definitions/postgresqlHelpers-2.js
@@ -75,13 +75,13 @@ async function select(tableName, objecten) {
     try {
         await client.query('BEGIN');
 
-        objecten.forEach(async (obj) => {
+        for(const obj of objecten) {
             let result = await executeAndLogStatement(client, selectStatement(tableName, Object.keys(obj), Object.values(obj)));
             results.push( {
                 result: result,
                 row: obj
             });
-        });
+        }
 
         await client.query('COMMIT');
     }

--- a/features/step_definitions/stepdefs.js
+++ b/features/step_definitions/stepdefs.js
@@ -87,7 +87,7 @@ After(async function() {
         return;
     }
     if(this.context.data) {
-        await rollback(this.context.sql, this.context.sqlData);
+        await rollback(this.context.sql, this.context.data);
     }
     else {
         await rollbackSqlStatements(this.context.sql, this.context.sqlData, global.pool);


### PR DESCRIPTION
- automation code gerefactored zodat bij integratie scenario's in de dan stappen de persoon en adres aanduiding om automatisch resp. de correcte pl_id en adres_id te bepalen. Hierdoor is het niet nodig om met een lege haal_centraal database te integratie testen uit te voeren
- de gegeven 'tabel [tabelnaam] heeft geen rijen' stap definitie en bijbehorende truncate functie zijn verwijderd. Deze is niet meer nodig omdat de pl_id en adres_id automatisch wordt bepaald
- @integratie tag bij scenario's verwijderd indien de Functionaliteit kenword hiermee is gedecoreerd. Tags worden door scenarios overgeërfd van hun regel/functionaliteit
- de deleteIndividualRecords functionaliteit is geïmplementeerd, zodat alleen geÏnserte rijen weer worden verwijderd ipv alle rijen in de tabellen