### PR TITLE
aanpassing functie voor erkenning

### DIFF
--- a/features/step_definitions/expressief/gegeven-stepdefs-erkenning.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-erkenning.js
@@ -88,7 +88,18 @@ function gegevenIsErkendDoorPersoonAlsOuder(context, aanduidingOuder, erkennings
         objectToDataTable(kindData)
     );
 
-    createOuder(
+    if (kind.hasOwnProperty('ouder-' + ouderType)) {
+      wijzigOuder(
+        kind, 
+        ouderType,
+        arrayOfArraysToDataTable([
+          ['burgerservicenummer (01.20)', getBsn(ouder)],
+          ['geslachtsnaam (02.40)', getGeslachtsnaam(ouder)],
+          ['aktenummer (81.20)', `1A${erkenningsType}0100`]
+        ], dataTable)
+      );
+    } else {
+      createOuder(
         kind,
         ouderType,
         arrayOfArraysToDataTable([
@@ -96,7 +107,8 @@ function gegevenIsErkendDoorPersoonAlsOuder(context, aanduidingOuder, erkennings
             ['geslachtsnaam (02.40)', getGeslachtsnaam(ouder)],
             ['aktenummer (81.20)', `1A${erkenningsType}0100`]
         ], dataTable)
-    );
+      );
+    }
 
     const data = [
         ['burgerservicenummer (01.20)', getBsn(kind)],

--- a/features/step_definitions/expressief/gegeven-stepdefs-erkenning.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-erkenning.js
@@ -1,5 +1,5 @@
 const { Given } = require('@cucumber/cucumber');
-const { createOuder, createKind, wijzigPersoon } = require('../persoon-2');
+const { createOuder, createKind, wijzigPersoon, wijzigOuder } = require('../persoon-2');
 const { getPersoon, getBsn, getGeslachtsnaam, getGeboortedatum, getGeslachtsaanduiding } = require('../contextHelpers');
 const { arrayOfArraysToDataTable, objectToDataTable } = require('../dataTableFactory');
 const { toBRPDate } = require('../brpDatum');


### PR DESCRIPTION
zodat het correct werkt als er al een ouder is

in de productiesituatie zijn er altijd twee categorieën ouder. wanneer er alleen een moeder is, dan is er een lege categorie ouder 2 opgevoerd. Wanneer daarna wordt erkend, dan moet dat correct werken door deze lege categorie historisch te maken (volg_nr + 1) en een nieuwe categorie ouder 2 toe te voegen (met volg_nr 0)

Daarom toegevoegd dat als er al een ouder (van betreffend type) is, de wijzigOuder functie wordt uitgevoerd en als er nog geen ouder is wordt createOuder uitgevoerd.