### PR TITLE
Geboortedatum familierechtelijke betrekking

### DIFF
--- a/features/step_definitions/gegeven-stepdefs-expressief.js
+++ b/features/step_definitions/gegeven-stepdefs-expressief.js
@@ -227,10 +227,21 @@ Given(/^is geboren in het buitenland/, function () {
 });
 
 Given(/^(?:'(.*)' )?is geboren op (\d*)-(\d*)-(\d*)$/, function (aanduiding, dag, maand, jaar) {
+    let persoon = getPersoon(this.context, aanduiding);
+    let geboortedatum = toBRPDate(dag, maand, jaar)
+
+    if (persoon.hasOwnProperty('ouder-1') && persoon['ouder-1'].at(-1).familie_betrek_start_datum == persoon.persoon.at(-1).geboorte_datum) {
+        persoon['ouder-1'].at(-1).familie_betrek_start_datum = geboortedatum
+    }
+
+    if (persoon.hasOwnProperty('ouder-2') && persoon['ouder-2'].at(-1).familie_betrek_start_datum == persoon.persoon.at(-1).geboorte_datum) {
+        persoon['ouder-2'].at(-1).familie_betrek_start_datum = geboortedatum
+    }
+
     aanvullenPersoon(
         getPersoon(this.context, aanduiding),
         arrayOfArraysToDataTable([
-            ['geboortedatum (03.10)', toBRPDate(dag, maand, jaar)]
+            ['geboortedatum (03.10)', geboortedatum]
         ])
     );
 });

--- a/features/step_definitions/gegeven-stepdefs-expressief.js
+++ b/features/step_definitions/gegeven-stepdefs-expressief.js
@@ -230,11 +230,11 @@ Given(/^(?:'(.*)' )?is geboren op (\d*)-(\d*)-(\d*)$/, function (aanduiding, dag
     let persoon = getPersoon(this.context, aanduiding);
     let geboortedatum = toBRPDate(dag, maand, jaar)
 
-    if (persoon.hasOwnProperty('ouder-1') && persoon['ouder-1'].at(-1).familie_betrek_start_datum == persoon.persoon.at(-1).geboorte_datum) {
+    if (persoon.hasOwnProperty('ouder-1') && persoon['ouder-1'].at(-1).hasOwnProperty('familie_betrek_start_datum') && persoon['ouder-1'].at(-1).familie_betrek_start_datum == persoon.persoon.at(-1).geboorte_datum) {
         persoon['ouder-1'].at(-1).familie_betrek_start_datum = geboortedatum
     }
 
-    if (persoon.hasOwnProperty('ouder-2') && persoon['ouder-2'].at(-1).familie_betrek_start_datum == persoon.persoon.at(-1).geboorte_datum) {
+    if (persoon.hasOwnProperty('ouder-2') && persoon['ouder-2'].at(-1).hasOwnProperty('familie_betrek_start_datum') && persoon['ouder-2'].at(-1).familie_betrek_start_datum == persoon.persoon.at(-1).geboorte_datum) {
         persoon['ouder-2'].at(-1).familie_betrek_start_datum = geboortedatum
     }
 


### PR DESCRIPTION
Ik heb de stap "is geboren op" uitgebreid zodat met het doorgeven van de geboortedatum ook de datum ingang familierechtelijke betrekking wordt aangepast naar de geboortedatum.

Dit gebeurt alleen wanneer:
- er als een ouder is opgegeven
- de datum ingang familierechtelijke betrekking al gevuld is en gelijk is aan de (default) geboortedatum