### PR TITLE
hernoemen stap is er geen gezag over

### DIFF
--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -557,7 +557,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         """
       Dan is het gezag over 'Bert' niet te bepalen met de toelichting 'dit is de reden dat het gezag niet te bepalen is. Het gaat om de volgende gegevens: geboortedatum'
 
-  Regel: Dan is er geen gezag
+  Regel: Dan heeft '{aanduidingMinderjarige}' geen gezaghouder
 
     Scenario: gevraagde persoon heeft geen gezagsrelaties
       Gegeven de response body is gelijk aan
@@ -570,4 +570,4 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
-      Dan is er geen gezag over 'Bert'
+      Dan heeft 'Bert' geen gezaghouder

--- a/features/step_definitions/dan-stepdefs-gezagsrelatie.js
+++ b/features/step_definitions/dan-stepdefs-gezagsrelatie.js
@@ -230,7 +230,7 @@ Then(/^heeft de (minderjarige|ouder|derde) geen (\w*)$/, function (type, propert
     }
 });
 
-Then('is er geen gezag over {string}', function (aanduidingMinderjarige) {
+Then('heeft {string} geen gezaghouder', function (aanduidingMinderjarige) {
     this.context.verifyResponse = true;
 
     const expected = {


### PR DESCRIPTION
In navolging van PR #58. Hierin is stap ```Dan is er geen gezag over {string}``` geïntroduceerd.

In PR [#246](https://github.com/BRP-API/brp-api-gezag/pull/246/files#diff-5470620e37fcc9ab830956d8056400f7487c932b92fafab1a459801512a21e9f ) wordt een andere stap gebruikt: ```Dan heeft {string} geen gezaghouder```

Ik heb de stapdefinitie gewijzigd naar die vorm