### PR TITLE
docs voor Dan stappen gezag bij meerdere gezagsrelaties

### DIFF
--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -794,3 +794,171 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
       En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
       En is het gezag over 'Bert' voogdij
       En is het gezag over 'Bert' voogdij met derde 'Aart'
+
+  Regel: Dan is het gezag in onderzoek
+
+    @info-api
+    Scenario: inOnderzoek wordt verwacht
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "gezag": [
+                {
+                  "type": "GezamenlijkOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012",
+                      "naam": {
+                        "volledigeNaam": "Gerda"
+                      }
+                    },
+                    {
+                      "burgerservicenummer": "000000024",
+                      "naam": {
+                        "volledigeNaam": "Aart"
+                      }
+                    }
+                  ],
+                  "inOnderzoek": true
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag in onderzoek
+
+    @data-api
+    Scenario: inOnderzoek wordt verwacht
+      Gegeven de persoon 'Bert' heeft de volgende gegevens
+        | geboortedatum (03.10) |
+        |              20221201 |
+      En de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "gezag": [
+                {
+                  "type": "GezamenlijkOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "geslachtsnaam": "Jansen"
+                    },
+                    "geboorte": {
+                      "datum": "20221201"
+                    }
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012",
+                      "naam": {
+                        "geslachtsnaam": "Gerda"
+                      }
+                    },
+                    {
+                      "burgerservicenummer": "000000024",
+                      "naam": {
+                        "geslachtsnaam": "Aart"
+                      }
+                    }
+                  ],
+                  "inOnderzoek": true
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag in onderzoek
+
+    @gezag-api @nieuw
+    Scenario: inOnderzoek wordt verwacht
+      Gegeven de persoon 'Bert' heeft de volgende gegevens
+        | geboortedatum (03.10) |
+        |              20221201 |
+      En de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "000000036",
+              "gezag": [
+                {
+                  "type": "GezamenlijkOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "geslachtsnaam": "Jansen"
+                    },
+                    "geboorte": {
+                      "datum": "20221201"
+                    }
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012",
+                      "naam": {
+                        "geslachtsnaam": "Gerda"
+                      }
+                    },
+                    {
+                      "burgerservicenummer": "000000024",
+                      "naam": {
+                        "geslachtsnaam": "Aart"
+                      }
+                    }
+                  ],
+                  "inOnderzoek": true
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag in onderzoek
+
+    @deprecated @gezag-api
+    Scenario: inOnderzoek wordt verwacht
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "000000036",
+              "gezag": [
+                {
+                  "type": "TweehoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012"
+                    },
+                    {
+                      "burgerservicenummer": "000000024"
+                    }
+                  ],
+                  "inOnderzoek": true
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag in onderzoek

--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -669,7 +669,6 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         {
           "personen": [
             {
-              "burgerservicenummer": "000000036",
               "gezag": [
                 {
                   "type": "GezamenlijkOuderlijkGezag",

--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -571,3 +571,226 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         }
         """
       Dan is er geen gezag over 'Bert'
+
+  Regel: De response kan meerdere gezagsrelaties bevatten
+    
+    @deprecated @gezag-api
+    Scenario: meerdere gezagsrelaties van één persoon
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "000000036",
+              "gezag": [
+                {
+                  "type": "TweehoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012"
+                    },
+                    {
+                      "burgerservicenummer": "000000024"
+                    }
+                  ]
+                },
+                {
+                  "type": "EenhoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012"
+                  }
+                },
+                {
+                  "type": "GezamenlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012"
+                  },
+                  "derde": {
+                    "type": "BekendeDerde",
+                    "burgerservicenummer": "000000024"
+                  }
+                },
+                {
+                  "type": "GezamenlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012"
+                  },
+                  "derde": {
+                    "type": "OnbekendeDerde"
+                  }
+                },
+                {
+                  "type": "Voogdij",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "derden": []
+                },
+                {
+                  "type": "Voogdij",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "derden": [
+                    {
+                      "type": "BekendeDerde",
+                      "burgerservicenummer": "000000024"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
+      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
+      En is het gezag over 'Bert' voogdij
+      En is het gezag over 'Bert' voogdij met derde 'Aart'
+
+    @info-api
+    Scenario: meerdere gezagsrelaties van één persoon
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "000000036",
+              "gezag": [
+                {
+                  "type": "GezamenlijkOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012",
+                      "naam": {
+                        "volledigeNaam": "Gerda"
+                      }
+                    },
+                    {
+                      "burgerservicenummer": "000000024",
+                      "naam": {
+                        "volledigeNaam": "Aart"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "EenhoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012",
+                    "naam": {
+                      "volledigeNaam": "Gerda"
+                    }
+                  }
+                },
+                {
+                  "type": "GezamenlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012",
+                    "naam": {
+                      "volledigeNaam": "Gerda"
+                    }
+                  },
+                  "derde": {
+                    "type": "BekendeDerde",
+                    "burgerservicenummer": "000000024",
+                    "naam": {
+                      "volledigeNaam": "Aart"
+                    }
+                  }
+                },
+                {
+                  "type": "GezamenlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012",
+                    "naam": {
+                      "volledigeNaam": "Gerda"
+                    }
+                  },
+                  "derde": {
+                    "type": "OnbekendeDerde"
+                  }
+                },
+                {
+                  "type": "Voogdij",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "derden": []
+                },
+                {
+                  "type": "Voogdij",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036",
+                    "naam": {
+                      "volledigeNaam": "Jansen"
+                    },
+                    "leeftijd": 2
+                  },
+                  "derden": [
+                    {
+                      "type": "BekendeDerde",
+                      "burgerservicenummer": "000000024",
+                      "naam": {
+                        "volledigeNaam": "Aart"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
+      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
+      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
+      En is het gezag over 'Bert' voogdij
+      En is het gezag over 'Bert' voogdij met derde 'Aart'

--- a/features/step_definitions/dan-stepdefs-gezagsrelatie.js
+++ b/features/step_definitions/dan-stepdefs-gezagsrelatie.js
@@ -123,7 +123,7 @@ function createDerde(context, aanduiding) {
     return retval;
 }
 
-function createPersoonMetGezag(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting = undefined) {
+function createGezag(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting = undefined) {
     let gezag = {
         type: type,
         minderjarige: createGezagspersoon(context, aanduidingMinderjarige, true)
@@ -165,55 +165,53 @@ function createPersoonMetGezag(context, type, aanduidingMinderjarige, aanduiding
             break;
     }
 
+    return gezag;
+}
+
+function createPersoonMetGezag(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting = undefined) {
     let retval = {
-        gezag: [gezag]
+        gezag: []
     }
     if(context.isGezagApiAanroep) {
         retval.burgerservicenummer = getBsn(getPersoon(context, aanduidingMinderjarige));
     }
+    retval.gezag.push(createGezag(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting));
     
     return retval;
 }
 
+function initExpected(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting = undefined) {
+    context.verifyResponse = true;
+
+    if(!context.expected) {
+        context.expected = {
+            personen: []
+        };
+    }
+
+    const expectedPersoon = context.expected.personen.at(-1);
+    if(!expectedPersoon) {
+        context.expected.personen.push(createPersoonMetGezag(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting));
+    }
+    else {
+        expectedPersoon.gezag.push(createGezag(context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2, toelichting));
+    }
+}
+
 Then(/^is het gezag over '(\w*)' (eenhoofdig ouderlijk gezag|gezamenlijk gezag) met ouder '(\w*)'(?: en een onbekende derde)?$/, function (aanduidingMinderjarige, type, aanduidingOuder) {
-    this.context.verifyResponse = true;
-
-    const expected = {
-        personen: [ createPersoonMetGezag(this.context, type, aanduidingMinderjarige, aanduidingOuder) ]
-    };
-
-    this.context.expected = expected;
+    initExpected(this.context, type, aanduidingMinderjarige, aanduidingOuder);
 });
 
 Then(/^is het gezag over '(\w*)' (gezamenlijk gezag|gezamenlijk ouderlijk gezag) met ouder '(\w*)' en (?:ouder|derde) '(\w*)'$/, function (aanduidingMinderjarige, type, aanduidingMeerderjarige1, aanduidingMeerderjarige2) {
-    this.context.verifyResponse = true;
-
-    const expected = {
-        personen: [ createPersoonMetGezag(this.context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2) ]
-    };
-
-    this.context.expected = expected;
-
+    initExpected(this.context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2);
 });
        
 Then(/^is het gezag over '(\w*)' voogdij(?: met derde '(\w*)')?$/, function (aanduidingMinderjarige, aanduidingMeerderjarige) {
-    this.context.verifyResponse = true;
-
-    const expected = {
-        personen: [ createPersoonMetGezag(this.context, 'voogdij', aanduidingMinderjarige, aanduidingMeerderjarige, undefined) ]
-    };
-
-    this.context.expected = expected;
+    initExpected(this.context, 'voogdij', aanduidingMinderjarige, aanduidingMeerderjarige);
 });
 
 Then(/^is het gezag over '(\w*)' (niet te bepalen|tijdelijk geen gezag) met de toelichting '([\wé.: ]*)'$/, function (aanduidingMinderjarige, type, toelichting) {
-    this.context.verifyResponse = true;
-
-    const expected = {
-        personen: [ createPersoonMetGezag(this.context, type, aanduidingMinderjarige, undefined, undefined, toelichting) ]
-    };
-
-    this.context.expected = expected;
+    initExpected(this.context, type, aanduidingMinderjarige, undefined, undefined, toelichting);
 });
 
 Then(/^heeft de (minderjarige|ouder|derde) de volgende gegevens$/, function (type, dataTable) {
@@ -242,4 +240,8 @@ Then('is er geen gezag over {string}', function (aanduidingMinderjarige) {
     };
 
     this.context.expected = expected;
+});
+
+Then('is het gezag in onderzoek', function () {
+    this.context.expected.personen.at(-1).gezag.at(-1).inOnderzoek = "true";
 });


### PR DESCRIPTION
De expressieve Dan stappen ondersteunen nu alleen nog maar één Dan stap per scenario. Wanneer er meerdere onder elkaar staan, dan wordt alleen de laatste gebruikt.

Scenario's toegevoegd die tonen dat er meerdere gezagsrelaties op één persoon kunnen komen.

@MelvLee kan jij de implementatie hiervan verzorgen?