### PR TITLE
wijzig partner vanuit partner zonder bsn

### DIFF
--- a/features/step_definitions/persoon-2.js
+++ b/features/step_definitions/persoon-2.js
@@ -184,6 +184,16 @@ function wijzigPartner(persoon, dataTable, isCorrectie = false, mergeProperties 
     });
 
     if (!partner) {
+        Object.keys(persoon).forEach(property => {
+            if (property.startsWith('partner')) {
+                if (!persoon[property].at(-1).burger_service_nr) {
+                    partner = persoon[property];
+                }
+            }
+        });
+    }
+
+    if (!partner) {
         global.logger.warn(`geen partner met bsn ${partnerData.burger_service_nr} gevonden`, persoon);
         return;
     }


### PR DESCRIPTION
Er zijn situaties dat in een scenario (in de S&T test) er eerst een partner is zonder burgerservicenummer, en dat dit wordt gewijzigd zodat er wel een burgerservicenummer is.

De functie wijzigPartner ondersteunde dit niet en gaf melding `geen partner met bsn ${partnerData.burger_service_nr} gevonden`.

Functie gewijzigd zodat in dit geval geprobeerd wordt een (de laatst toegevoegde?) partner te vinden die nu nog geen  burgerservicenummer heeft. Die wordt dan gewijzigd.