### PR TITLE
meerdere gezagsrelaties met juiste burgerservicenummer van persoon

### DIFF
--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -572,9 +572,8 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         """
       Dan heeft 'Bert' geen gezaghouder
 
-  Regel: De gezag API levert daarbij het burgerservicenummer van de persoon waarvan het gezag gevraagd is
+  Regel: Dan heeft '{aanduidingMeerderjarige}' de volgende gezagsrelaties En het gezag over '{aanduidingMinderjarige}' is ...
     Dat kan de minderjarige zijn, maar ook een ouder of derde.
-    Welk burgerservicenummer dit is wordt uitgeleid uit de Als stap.
 
     @deprecated @gezag-api
     Scenario: het gezag van de <omschrijving> met gezamenlijk ouderlijk gezag wordt gevraagd
@@ -604,14 +603,14 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
-      Als 'gezag' wordt gevraagd van '<naam>'
-      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      Dan heeft '<naam>' de volgende gezagsrelaties
+      * het gezag over 'Bert' is gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
 
       Voorbeelden:
-        | aanduiding | burgerservicenummer | omschrijving |
-        | Gerda      |           000000012 | ouder 1      |
-        | Aart       |           000000024 | ouder 2      |
-        | Bert       |           000000036 | minderjarige |
+        | naam  | burgerservicenummer | omschrijving |
+        | Gerda |           000000012 | ouder 1      |
+        | Aart  |           000000024 | ouder 2      |
+        | Bert  |           000000036 | minderjarige |
 
     @deprecated @gezag-api
     Scenario: het gezag van de <omschrijving> met gezamenlijk gezag wordt gevraagd
@@ -640,35 +639,22 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
-      Als 'gezag' wordt gevraagd van '<naam>'
-      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      Dan heeft '<naam>' de volgende gezagsrelaties
+      * het gezag over 'Bert' is gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
 
       Voorbeelden:
-        | aanduiding | burgerservicenummer | omschrijving |
-        | Gerda      |           000000012 | ouder        |
-        | Aart       |           000000024 | derde        |
-        | Bert       |           000000036 | minderjarige |
-
-    @gezag-api
-    Scenario: gevraagde persoon heeft geen gezagsrelaties
-      Gegeven de response body is gelijk aan
-        """
-        {
-          "personen": [
-            {
-              "burgerservicenummer": "000000024",
-              "gezag": []
-            }
-          ]
-        }
-        """
-      Als 'gezag' wordt gevraagd van 'Aart'
-      Dan heeft 'Aart' geen gezaghouder
-
-  Regel: De response kan meerdere gezagsrelaties bevatten
+        | naam  | burgerservicenummer | omschrijving |
+        | Gerda |           000000012 | ouder        |
+        | Aart  |           000000024 | derde        |
+        | Bert  |           000000036 | minderjarige |
 
     @deprecated @gezag-api
     Scenario: meerdere gezagsrelaties van één persoon
+      Gegeven de persoon 'Ernie' met burgerservicenummer '000000048'
+      En de persoon 'Ieniemienie' met burgerservicenummer '000000061'
+      En de persoon 'Pino' met burgerservicenummer '000000073'
+      En de persoon 'Tommy' met burgerservicenummer '000000085'
+      En de persoon 'Kermit' met burgerservicenummer '000000097'
       Gegeven de response body is gelijk aan
         """
         {
@@ -693,7 +679,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "EenhoofdigOuderlijkGezag",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036"
+                    "burgerservicenummer": "000000048"
                   },
                   "ouder": {
                     "burgerservicenummer": "000000012"
@@ -702,7 +688,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "GezamenlijkGezag",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036"
+                    "burgerservicenummer": "000000061"
                   },
                   "ouder": {
                     "burgerservicenummer": "000000012"
@@ -715,7 +701,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "GezamenlijkGezag",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036"
+                    "burgerservicenummer": "000000073"
                   },
                   "ouder": {
                     "burgerservicenummer": "000000012"
@@ -727,14 +713,14 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "Voogdij",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036"
+                    "burgerservicenummer": "000000085"
                   },
                   "derden": []
                 },
                 {
                   "type": "Voogdij",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036"
+                    "burgerservicenummer": "000000097"
                   },
                   "derden": [
                     {
@@ -748,13 +734,13 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
-      Als 'gezag' wordt gevraagd van '<naam>'
-      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
-      En is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
-      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
-      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
-      En is het gezag over 'Bert' voogdij
-      En is het gezag over 'Bert' voogdij met derde 'Aart'
+      Dan heeft '<naam>' de volgende gezagsrelaties
+      * het gezag over 'Bert' is gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      * het gezag over 'Ernie' is eenhoofdig ouderlijk gezag met ouder 'Gerda'
+      * het gezag over 'Ieniemienie' is gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
+      * het gezag over 'Pino' is gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
+      * het gezag over 'Tommy' is voogdij
+      * het gezag over 'Kermit' is voogdij met derde 'Aart'
 
       Voorbeelden:
         | naam  | burgerservicenummer |
@@ -763,6 +749,21 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
 
     @info-api
     Scenario: meerdere gezagsrelaties van één persoon
+      Gegeven de persoon 'Ernie' heeft de volgende gegevens
+        | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
+        |                   000000048 | Ernie                 | gisteren - 3 jaar     |
+      En de persoon 'Ieniemienie' heeft de volgende gegevens
+        | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
+        |                   000000061 | Ieniemienie           | gisteren - 4 jaar     |
+      En de persoon 'Pino' heeft de volgende gegevens
+        | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
+        |                   000000073 | Pino                  | gisteren - 5 jaar     |
+      En de persoon 'Tommy' heeft de volgende gegevens
+        | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
+        |                   000000085 | Tommy                 | gisteren - 6 jaar     |
+      En de persoon 'Kermit' heeft de volgende gegevens
+        | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
+        |                   000000097 | Kermit                | gisteren - 7 jaar     |
       Gegeven de response body is gelijk aan
         """
         {
@@ -796,11 +797,11 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "EenhoofdigOuderlijkGezag",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036",
+                    "burgerservicenummer": "000000048",
                     "naam": {
-                      "volledigeNaam": "Jansen"
+                      "volledigeNaam": "Ernie"
                     },
-                    "leeftijd": 2
+                    "leeftijd": 3
                   },
                   "ouder": {
                     "burgerservicenummer": "000000012",
@@ -812,11 +813,11 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "GezamenlijkGezag",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036",
+                    "burgerservicenummer": "000000061",
                     "naam": {
-                      "volledigeNaam": "Jansen"
+                      "volledigeNaam": "Ieniemienie"
                     },
-                    "leeftijd": 2
+                    "leeftijd": 4
                   },
                   "ouder": {
                     "burgerservicenummer": "000000012",
@@ -835,11 +836,11 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "GezamenlijkGezag",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036",
+                    "burgerservicenummer": "000000073",
                     "naam": {
-                      "volledigeNaam": "Jansen"
+                      "volledigeNaam": "Pino"
                     },
-                    "leeftijd": 2
+                    "leeftijd": 5
                   },
                   "ouder": {
                     "burgerservicenummer": "000000012",
@@ -854,22 +855,22 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                 {
                   "type": "Voogdij",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036",
+                    "burgerservicenummer": "000000085",
                     "naam": {
-                      "volledigeNaam": "Jansen"
+                      "volledigeNaam": "Tommy"
                     },
-                    "leeftijd": 2
+                    "leeftijd": 6
                   },
                   "derden": []
                 },
                 {
                   "type": "Voogdij",
                   "minderjarige": {
-                    "burgerservicenummer": "000000036",
+                    "burgerservicenummer": "000000097",
                     "naam": {
-                      "volledigeNaam": "Jansen"
+                      "volledigeNaam": "Kermit"
                     },
-                    "leeftijd": 2
+                    "leeftijd": 7
                   },
                   "derden": [
                     {
@@ -886,12 +887,18 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
-      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
-      En is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
-      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
-      En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
-      En is het gezag over 'Bert' voogdij
-      En is het gezag over 'Bert' voogdij met derde 'Aart'
+      Dan heeft '<naam>' de volgende gezagsrelaties
+      * het gezag over 'Bert' is gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      * het gezag over 'Ernie' is eenhoofdig ouderlijk gezag met ouder 'Gerda'
+      * het gezag over 'Ieniemienie' is gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
+      * het gezag over 'Pino' is gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
+      * het gezag over 'Tommy' is voogdij
+      * het gezag over 'Kermit' is voogdij met derde 'Aart'
+
+      Voorbeelden:
+        | naam  | burgerservicenummer |
+        | Gerda |           000000012 |
+        | Aart  |           000000024 |
 
   Regel: Dan is het gezag in onderzoek
 
@@ -1060,3 +1067,47 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         """
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
       En is het gezag in onderzoek
+
+    @deprecated @gezag-api
+    Scenario: vragen gezag meerderjarige en één van de gezagsrelaties verwacht inOnderzoek
+      Gegeven de persoon 'Ernie' met burgerservicenummer '000000048'
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "<burgerservicenummer>",
+              "gezag": [
+                {
+                  "type": "TweehoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012"
+                    },
+                    {
+                      "burgerservicenummer": "000000024"
+                    }
+                  ],
+                  "inOnderzoek": true
+                },
+                {
+                  "type": "EenhoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000048"
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Dan heeft '<naam>' de volgende gezagsrelaties
+      * het gezag over 'Bert' is gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+      En is het gezag in onderzoek
+      * het gezag over 'Ernie' is eenhoofdig ouderlijk gezag met ouder 'Gerda'

--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -7,11 +7,11 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
     Gegeven de persoon 'Gerda' met burgerservicenummer '000000012'
     En de persoon 'Aart' met burgerservicenummer '000000024'
     En de persoon 'Bert' heeft de volgende gegevens
-      | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
-      |                   000000036 | Jansen                | gisteren - 2 jaar     |
+      | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) | geslachtsaanduiding (04.10) |
+      |                   000000036 | Jansen                | gisteren - 2 jaar     | M                           |
     En de persoon 'Jeanette' heeft de volgende gegevens
-      | voornamen (02.10) | geslachtsnaam (02.40) |
-      | Jeanette          | Sanders               |
+      | voornamen (02.10) | geslachtsnaam (02.40) | geslachtsaanduiding (04.10) |
+      | Jeanette          | Sanders               | V                           |
 
   Regel: Dan is het gezag over '{aanduiding minderjarige}' gezamenlijk ouderlijk gezag met ouder '{aanduiding ouder}' en ouder '{aanduiding ouder}'
     De volgorde waarin ouders genoemd worden is willekeurig en niet relevant
@@ -73,6 +73,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                     "naam": {
                       "geslachtsnaam": "Jansen"
                     },
+                    "geslacht": {
+                      "code": "M"
+                    },
                     "geboorte": {
                       "datum": "20221201"
                     }
@@ -117,6 +120,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                     "burgerservicenummer": "000000036",
                     "naam": {
                       "geslachtsnaam": "Jansen"
+                    },
+                    "geslacht": {
+                      "code": "M"
                     },
                     "geboorte": {
                       "datum": "20221201"
@@ -231,6 +237,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                     "naam": {
                       "geslachtsnaam": "Jansen"
                     },
+                    "geslacht": {
+                      "code": "M"
+                    },
                     "geboorte": {
                       "datum": "20221201"
                     }
@@ -246,6 +255,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                       "naam": {
                         "voornamen": "Jeanette",
                         "geslachtsnaam": "Sanders"
+                      },
+                      "geslacht": {
+                        "code": "V"
                       }
                     }
                   ]
@@ -276,6 +288,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                     "naam": {
                       "geslachtsnaam": "Jansen"
                     },
+                    "geslacht": {
+                      "code": "M"
+                    },
                     "geboorte": {
                       "datum": "20221201"
                     }
@@ -291,6 +306,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                       "naam": {
                         "voornamen": "Jeanette",
                         "geslachtsnaam": "Sanders"
+                      },
+                      "geslacht": {
+                        "code": "V"
                       }
                     }
                   ]
@@ -977,6 +995,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                     "naam": {
                       "geslachtsnaam": "Jansen"
                     },
+                    "geslacht": {
+                      "code": "M"
+                    },
                     "geboorte": {
                       "datum": "20221201"
                     }
@@ -1023,6 +1044,9 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
                     "burgerservicenummer": "000000036",
                     "naam": {
                       "geslachtsnaam": "Jansen"
+                    },
+                    "geslacht": {
+                      "code": "M"
                     },
                     "geboorte": {
                       "datum": "20221201"

--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -573,7 +573,10 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
       Dan heeft 'Bert' geen gezaghouder
 
   Regel: De response kan meerdere gezagsrelaties bevatten
-    
+    De gezag API levert daarbij het burgerservicenummer van de persoon waarvan het gezag gevraagd is.
+    Dat kan de minderjarige zijn, maar ook een ouder of derde.
+    Welk burgerservicenummer dit is wordt uitgeleid uit de Als stap.
+
     @deprecated @gezag-api
     Scenario: meerdere gezagsrelaties van één persoon
       Gegeven de response body is gelijk aan
@@ -581,7 +584,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         {
           "personen": [
             {
-              "burgerservicenummer": "000000036",
+              "burgerservicenummer": "<burgerservicenummer>",
               "gezag": [
                 {
                   "type": "TweehoofdigOuderlijkGezag",
@@ -655,12 +658,18 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
+      Als 'gezag' wordt gevraagd van '<naam>'
       Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
       En is het gezag over 'Bert' eenhoofdig ouderlijk gezag met ouder 'Gerda'
       En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en derde 'Aart'
       En is het gezag over 'Bert' gezamenlijk gezag met ouder 'Gerda' en een onbekende derde
       En is het gezag over 'Bert' voogdij
       En is het gezag over 'Bert' voogdij met derde 'Aart'
+
+      Voorbeelden:
+        | naam  | burgerservicenummer |
+        | Gerda |           000000012 |
+        | Aart  |           000000024 |
 
     @info-api
     Scenario: meerdere gezagsrelaties van één persoon

--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -665,7 +665,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         | Bert  |           000000036 | minderjarige |
 
     @deprecated @gezag-api
-    Scenario: meerdere gezagsrelaties van één persoon
+    Abstract Scenario: meerdere gezagsrelaties van één persoon
       Gegeven de persoon 'Ernie' met burgerservicenummer '000000048'
       En de persoon 'Ieniemienie' met burgerservicenummer '000000061'
       En de persoon 'Pino' met burgerservicenummer '000000073'
@@ -764,7 +764,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         | Aart  |           000000024 |
 
     @info-api
-    Scenario: meerdere gezagsrelaties van één persoon
+    Abstract Scenario: meerdere gezagsrelaties van één persoon
       Gegeven de persoon 'Ernie' heeft de volgende gegevens
         | burgerservicenummer (01.20) | geslachtsnaam (02.40) | geboortedatum (03.10) |
         |                   000000048 | Ernie                 | gisteren - 3 jaar     |
@@ -1092,7 +1092,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         {
           "personen": [
             {
-              "burgerservicenummer": "<burgerservicenummer>",
+              "burgerservicenummer": "000000048",
               "gezag": [
                 {
                   "type": "TweehoofdigOuderlijkGezag",
@@ -1123,7 +1123,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
           ]
         }
         """
-      Dan heeft '<naam>' de volgende gezagsrelaties
+      Dan heeft 'Ernie' de volgende gezagsrelaties
       * het gezag over 'Bert' is gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
       En is het gezag in onderzoek
       * het gezag over 'Ernie' is eenhoofdig ouderlijk gezag met ouder 'Gerda'

--- a/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
+++ b/features/docs/dan-stap-definities-gezagsrelatie-expressief.feature
@@ -572,10 +572,100 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         """
       Dan heeft 'Bert' geen gezaghouder
 
-  Regel: De response kan meerdere gezagsrelaties bevatten
-    De gezag API levert daarbij het burgerservicenummer van de persoon waarvan het gezag gevraagd is.
+  Regel: De gezag API levert daarbij het burgerservicenummer van de persoon waarvan het gezag gevraagd is
     Dat kan de minderjarige zijn, maar ook een ouder of derde.
     Welk burgerservicenummer dit is wordt uitgeleid uit de Als stap.
+
+    @deprecated @gezag-api
+    Scenario: het gezag van de <omschrijving> met gezamenlijk ouderlijk gezag wordt gevraagd
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "<burgerservicenummer>",
+              "gezag": [
+                {
+                  "type": "TweehoofdigOuderlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouders": [
+                    {
+                      "burgerservicenummer": "000000012"
+                    },
+                    {
+                      "burgerservicenummer": "000000024"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Als 'gezag' wordt gevraagd van '<naam>'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+      Voorbeelden:
+        | aanduiding | burgerservicenummer | omschrijving |
+        | Gerda      |           000000012 | ouder 1      |
+        | Aart       |           000000024 | ouder 2      |
+        | Bert       |           000000036 | minderjarige |
+
+    @deprecated @gezag-api
+    Scenario: het gezag van de <omschrijving> met gezamenlijk gezag wordt gevraagd
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "<burgerservicenummer>",
+              "gezag": [
+                {
+                  "type": "GezamenlijkGezag",
+                  "minderjarige": {
+                    "burgerservicenummer": "000000036"
+                  },
+                  "ouder": {
+                    "burgerservicenummer": "000000012"
+                  },
+                  "derde": {
+                    "type": "BekendeDerde",
+                    "burgerservicenummer": "000000024"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        """
+      Als 'gezag' wordt gevraagd van '<naam>'
+      Dan is het gezag over 'Bert' gezamenlijk ouderlijk gezag met ouder 'Gerda' en ouder 'Aart'
+
+      Voorbeelden:
+        | aanduiding | burgerservicenummer | omschrijving |
+        | Gerda      |           000000012 | ouder        |
+        | Aart       |           000000024 | derde        |
+        | Bert       |           000000036 | minderjarige |
+
+    @gezag-api
+    Scenario: gevraagde persoon heeft geen gezagsrelaties
+      Gegeven de response body is gelijk aan
+        """
+        {
+          "personen": [
+            {
+              "burgerservicenummer": "000000024",
+              "gezag": []
+            }
+          ]
+        }
+        """
+      Als 'gezag' wordt gevraagd van 'Aart'
+      Dan heeft 'Aart' geen gezaghouder
+
+  Regel: De response kan meerdere gezagsrelaties bevatten
 
     @deprecated @gezag-api
     Scenario: meerdere gezagsrelaties van één persoon

--- a/features/step_definitions/dan-stepdefs-gezagsrelatie.js
+++ b/features/step_definitions/dan-stepdefs-gezagsrelatie.js
@@ -7,6 +7,7 @@ const { createCollectieObjectMetSubCollectieObject,
         createSubSubCollectieObjectenInLastSubCollectieObjectInLastCollectieObject } = require('./dataTable2ObjectFactory');
 const { setObjectPropertiesFrom } = require('./dataTable2Object');
 const { getBsn,
+        getGeslachtsaanduiding,
         getGeslachtsnaam,
         getVoornamen,
         getGeboortedatum,
@@ -65,6 +66,25 @@ function setProperty(obj, key, value) {
     }
 }
 
+function setGezagRelatieProperties(persoon, retval, isMinderjarige) {
+    retval.naam = {};
+
+    setProperty(retval.naam, 'voornamen', getVoornamen(persoon));
+    setProperty(retval.naam, 'geslachtsnaam', getGeslachtsnaam(persoon));
+    const geslachtsaanduiding = getGeslachtsaanduiding(persoon);
+    if(geslachtsaanduiding) {
+        retval.geslacht = {};
+
+        setProperty(retval.geslacht, 'code', geslachtsaanduiding);
+    }
+
+    if(isMinderjarige) {
+        retval.geboorte = {};
+
+        setProperty(retval.geboorte, 'datum', getGeboortedatum(persoon));
+    }
+}
+
 function createGezagspersoon(context, aanduiding, isMinderjarige = false) {
     const persoon = getPersoon(context, aanduiding);
 
@@ -83,29 +103,11 @@ function createGezagspersoon(context, aanduiding, isMinderjarige = false) {
         }
     }
     if((context.isAllApiScenario || context.isDataApiScenario) && context.isDataApiAanroep) {
-        retval.naam = {};
-
-        setProperty(retval.naam, 'voornamen', getVoornamen(persoon));
-        setProperty(retval.naam, 'geslachtsnaam', getGeslachtsnaam(persoon));
-
-        if(isMinderjarige) {
-            retval.geboorte = {};
-
-            setProperty(retval.geboorte, 'datum', getGeboortedatum(persoon));
-        }
+        setGezagRelatieProperties(persoon, retval, isMinderjarige);
     }
     if((context.isAllApiScenario || context.isGezagApiScenario) && context.isGezagApiAanroep) {
         if(!context.isDeprecatedScenario) {
-            retval.naam = {};
-
-            setProperty(retval.naam, 'voornamen', getVoornamen(persoon));
-            setProperty(retval.naam, 'geslachtsnaam', getGeslachtsnaam(persoon));
-
-            if(isMinderjarige) {
-                retval.geboorte = {};
-
-                setProperty(retval.geboorte, 'datum', getGeboortedatum(persoon));
-            }
+            setGezagRelatieProperties(persoon, retval, isMinderjarige);
         }
     }
 

--- a/features/step_definitions/dan-stepdefs-gezagsrelatie.js
+++ b/features/step_definitions/dan-stepdefs-gezagsrelatie.js
@@ -198,15 +198,15 @@ function initExpected(context, type, aanduidingMinderjarige, aanduidingMeerderja
     }
 }
 
-Then(/^is het gezag over '([a-zA-Z0-9À-ž-]*)' (eenhoofdig ouderlijk gezag|gezamenlijk gezag) met ouder '([a-zA-Z0-9À-ž-]*)'(?: en een onbekende derde)?$/, function (aanduidingMinderjarige, type, aanduidingOuder) {
+Then(/^(?:is )?het gezag over '([a-zA-Z0-9À-ž-]*)' (?:is )?(eenhoofdig ouderlijk gezag|gezamenlijk gezag) met ouder '([a-zA-Z0-9À-ž-]*)'(?: en een onbekende derde)?$/, function (aanduidingMinderjarige, type, aanduidingOuder) {
     initExpected(this.context, type, aanduidingMinderjarige, aanduidingOuder);
 });
 
-Then(/^is het gezag over '([a-zA-Z0-9À-ž-]*)' (gezamenlijk gezag|gezamenlijk ouderlijk gezag) met ouder '([a-zA-Z0-9À-ž-]*)' en (?:ouder|derde) '([a-zA-Z0-9À-ž-]*)'$/, function (aanduidingMinderjarige, type, aanduidingMeerderjarige1, aanduidingMeerderjarige2) {
+Then(/^(?:is )?het gezag over '([a-zA-Z0-9À-ž-]*)' (?:is )?(gezamenlijk gezag|gezamenlijk ouderlijk gezag) met ouder '([a-zA-Z0-9À-ž-]*)' en (?:ouder|derde) '([a-zA-Z0-9À-ž-]*)'$/, function (aanduidingMinderjarige, type, aanduidingMeerderjarige1, aanduidingMeerderjarige2) {
     initExpected(this.context, type, aanduidingMinderjarige, aanduidingMeerderjarige1, aanduidingMeerderjarige2);
 });
        
-Then(/^is het gezag over '([a-zA-Z0-9À-ž-]*)' voogdij(?: met derde '([a-zA-Z0-9À-ž-]*)')?$/, function (aanduidingMinderjarige, aanduidingMeerderjarige) {
+Then(/^(?:is )?het gezag over '([a-zA-Z0-9À-ž-]*)' (?:is )?voogdij(?: met derde '([a-zA-Z0-9À-ž-]*)')?$/, function (aanduidingMinderjarige, aanduidingMeerderjarige) {
     initExpected(this.context, 'voogdij', aanduidingMinderjarige, aanduidingMeerderjarige);
 });
 
@@ -248,4 +248,22 @@ Then('heeft {aanduiding} geen gezaghouder', function (aanduidingMinderjarige) {
 
 Then('is het gezag in onderzoek', function () {
     this.context.expected.personen.at(-1).gezag.at(-1).inOnderzoek = "true";
+});
+
+Then('heeft {aanduiding} de volgende gezagsrelaties', function (aanduiding) {
+    this.context.verifyResponse = true;
+
+    if(!this.context.expected) {
+        this.context.expected = {
+            personen: []
+        };
+    }
+
+    let persoon = {
+        gezag: []
+    }
+    if(this.context.isGezagApiAanroep) {
+        persoon.burgerservicenummer = getBsn(getPersoon(this.context, aanduiding));
+    }
+    this.context.expected.personen.push(persoon);
 });


### PR DESCRIPTION
in PR #61 was de beschrijving nog niet helemaal goed. De Gezag API levert namelijk per persoon het burgerservicenummer. Wanneer een meerderjarige wordt bevraagd - dit is dé situatie waarbij er meerdere gezagsrelaties kunnen zijn - is het bijgeleverde burgerservicenummer niet af te leiden uit de Dan stap. Dit is wel af te leiden uit de Als stap.

Hiermee is er trouwens nog geen oplossing voor het vragen van gezag voor meerdere personen tegelijk. Daar zijn dan andere Dan stappen nodig, die wel aangeven voor welke persoon dit gezag geldt.