### PR TITLE
Stepdefs aangevuld voor gezag features

### DIFF
--- a/features/docs/gegeven-stap-definities-gezag/partner.feature
+++ b/features/docs/gegeven-stap-definities-gezag/partner.feature
@@ -124,6 +124,29 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         |    2 jaar geleden |
         | gisteren - 5 jaar |
 
+    Scenario: '{naam1}' en '{naam2}' zijn op {dd-mm-yyyy datum} gescheiden
+      Gegeven de persoon 'P1' met burgerservicenummer '000000012'
+      En de persoon 'P2' met burgerservicenummer '000000024'
+      En 'P1' en 'P2' zijn met elkaar gehuwd
+      En 'P1' en 'P2' zijn 3-7-2023 gescheiden
+      Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+      Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
+        | pl_id | geheim_ind |
+        | P1    |          0 |
+      En heeft persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
+        | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code | verbintenis_soort |
+        | P1    | P            |         0 |       0 |         000000012 | P1             |               6030 | 1AA0100 |                     |                      |                         |                    |                     |                        |                   |
+        | P1    | R            |         0 |       1 |         000000024 | P2             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 |                    |                     |                        | H                 |
+        | P1    | R            |         0 |       0 |         000000024 | P2             |                    |         |                     |                      |                         |           20230703 |                0518 |                   6030 | H                 |
+      En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl'
+        | pl_id | geheim_ind |
+        | P2    |          0 |
+      En heeft persoon 'P2' de volgende rijen in tabel 'lo3_pl_persoon'
+        | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code | verbintenis_soort |
+        | P2    | P            |         0 |       0 |         000000024 | P2             |               6030 | 1AA0100 |                     |                      |                         |                    |                     |                        |                   |
+        | P2    | R            |         0 |       1 |         000000012 | P1             |                    |         | gisteren - 20 jaar  |                 0518 |                    6030 |                    |                     |                        | H                 |
+        | P2    | R            |         0 |       0 |         000000012 | P1             |                    |         |                     |                      |                         |           20230703 |                0518 |                   6030 | H                 |
+
     @integratie
     Abstract Scenario: volgende relatie: '{naam1}' en '{naam2}' zijn {relatievedatum} gehuwd
       Gegeven de persoon 'P1' met burgerservicenummer '000000012'

--- a/features/docs/gegeven-stap-definities-gezag/partner.feature
+++ b/features/docs/gegeven-stap-definities-gezag/partner.feature
@@ -182,7 +182,7 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         | P2    | R            |         0 |       0 |         000000012 | P1             |                    |         |                     |                      |                         |     2 jaar geleden |                0518 |                   6030 | H                 |
 
     @integratie
-    Scenario: personen zijn gehuwd, gescheiden en opnieuw gehuwd
+    Scenario: personen zijn gehuwd, gescheiden en daarna gehuwd met een ander
       Gegeven de persoon 'P1' met burgerservicenummer '000000012'
       En de persoon 'P2' met burgerservicenummer '000000024'
       En de persoon 'P3' met burgerservicenummer '000000036'
@@ -224,6 +224,33 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code | verbintenis_soort |
         | P4    | P            |         0 |       0 |         000000048 | P4             |               6030 | 1AA0100 |                     |                      |                         |                    |                     |                        |                   |
         | P4    | R            |         0 |       0 |         000000012 | P1             |                    |         |      5 jaar geleden |                 0518 |                    6030 |                    |                     |                        | H                 |
+
+    @integratie
+    Scenario: personen zijn gehuwd, gescheiden en opnieuw gehuwd
+      Gegeven de persoon 'P1' met burgerservicenummer '000000012'
+      En de persoon 'P2' met burgerservicenummer '000000024'
+      En 'P1' en 'P2' zijn 10 jaar geleden gehuwd
+      En 'P1' en 'P2' zijn 7 jaar geleden gescheiden
+      En 'P1' en 'P2' zijn 5 jaar geleden opnieuw gehuwd
+      Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+      Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
+        | pl_id | geheim_ind |
+        | P1    |          0 |
+      En heeft persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
+        | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code | verbintenis_soort |
+        | P1    | P            |         0 |       0 |         000000012 | P1             |               6030 | 1AA0100 |                     |                      |                         |                    |                     |                        |                   |
+        | P1    | R            |         0 |       1 |         000000024 | P2             |                    |         |     10 jaar geleden |                 0518 |                    6030 |                    |                     |                        | H                 |
+        | P1    | R            |         0 |       0 |         000000024 | P2             |                    |         |                     |                      |                         |     7 jaar geleden |                0518 |                   6030 | H                 |
+        | P1    | R            |         1 |       0 |         000000024 | P2             |                    |         |      5 jaar geleden |                 0518 |                    6030 |                    |                     |                        | H                 |
+      En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl'
+        | pl_id | geheim_ind |
+        | P2    |          0 |
+      En heeft persoon 'P2' de volgende rijen in tabel 'lo3_pl_persoon'
+        | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam | geboorte_land_code | akte_nr | relatie_start_datum | relatie_start_plaats | relatie_start_land_code | relatie_eind_datum | relatie_eind_plaats | relatie_eind_land_code | verbintenis_soort |
+        | P2    | P            |         0 |       0 |         000000024 | P2             |               6030 | 1AA0100 |                     |                      |                         |                    |                     |                        |                   |
+        | P2    | R            |         0 |       1 |         000000012 | P1             |                    |         |     10 jaar geleden |                 0518 |                    6030 |                    |                     |                        | H                 |
+        | P2    | R            |         0 |       0 |         000000012 | P1             |                    |         |                     |                      |                         |     7 jaar geleden |                0518 |                   6030 | H                 |
+        | P2    | R            |         1 |       0 |         000000012 | P1             |                    |         |      5 jaar geleden |                 0518 |                    6030 |                    |                     |                        | H                 |
 
     Abstract Scenario: het geregistreerd partnerschap van '{naam1} en {naam2}' is {relatieve datum} ontbonden
       Gegeven de persoon 'P1' met burgerservicenummer '000000012'

--- a/features/docs/gegeven-stap-definities-gezag/verblijfplaats.feature
+++ b/features/docs/gegeven-stap-definities-gezag/verblijfplaats.feature
@@ -153,3 +153,18 @@ Functionaliteit: Stap definities ten behoeve van specificeren gezagsrelaties
         | Spanje      |      6037 |
         | Duitsland   |      6029 |
         | Afghanistan |      6023 |
+
+    @integratie
+    Scenario: {vandaag, gisteren of morgen x jaar geleden} is geconstateerd dat {aanduiding} behoort tot de categorie NAVO-militair
+      Gegeven de persoon 'P1' met burgerservicenummer '000000012'
+      En 2 jaar geleden is geconstateerd dat 'P1' behoort tot de categorie NAVO-militair
+      Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+      Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
+        | pl_id | geheim_ind | bijhouding_opschort_datum | bijhouding_opschort_reden |
+        | P1    |          0 |            2 jaar geleden | M                         |
+      En heeft persoon 'P1' de volgende rijen in tabel 'lo3_pl_persoon'
+        | pl_id | persoon_type | stapel_nr | volg_nr | burger_service_nr | geslachts_naam |
+        | P1    | P            |         0 |       0 |         000000012 | P1             |
+      En heeft persoon 'P1' de volgende rijen in tabel 'lo3_pl_verblijfplaats'
+        | pl_id | volg_nr | inschrijving_gemeente_code | vertrek_datum  | vertrek_land_code | aangifte_adreshouding_oms |
+        | P1    |       0 |                       0518 | 2 jaar geleden |              0000 | B                         |

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -75,6 +75,22 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
       | op 21-01-2021          | man           |         20210121 | M                   |
 
   @integratie
+  Abstract Scenario: de {meer- of minderjarige} {geslacht type} '{persoon aanduiding}'
+    Gegeven de <omschrijving persoon> 'Jansen'
+    Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+    Dan heeft persoon 'Jansen' de volgende rij in tabel 'lo3_pl'
+      | pl_id  | geheim_ind |
+      | Jansen |          0 |
+    En heeft persoon 'Jansen' de volgende rij in tabel 'lo3_pl_persoon'
+      | pl_id  | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam | geboorte_datum  | geboorte_land_code | geslachts_aand        | akte_nr |
+      | Jansen |         0 |       0 | P            |         000000012 | Jansen         | <geboortedatum> |               6030 | <geslachtsaanduiding> | 1_A____ |
+
+    Voorbeelden:
+      | omschrijving persoon | geboortedatum      | geslachtsaanduiding |
+      | minderjarige         | gisteren - 17 jaar |                     |
+      | meerderjarige vrouw  | gisteren - 45 jaar | V                   |
+
+  @integratie
   Scenario: de {datum} geboren {geslacht type} '{persoon aanduiding}'
     Gegeven de vandaag 5 jaar geleden geboren man 'Jansen'
     En de op 21 januari 2021 geboren vrouw 'Pietersen'

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -283,3 +283,4 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
       | de op 21-01-2021 geboren inwoner 'P1'          |           20210121 |
       | de op een onbekende datum geboren inwoner 'P1' |           00000000 |
       | de minderjarige inwoner 'P1'                   | gisteren - 17 jaar |
+      | de meerderjarige inwoner 'P1'                  | gisteren - 45 jaar |

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -260,3 +260,26 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
       | stap | categorie    | text                                                                                                             | values               |
       |    1 | inschrijving | INSERT INTO public.lo3_pl(pl_id,mutatie_dt,geheim_ind) VALUES(9999,current_timestamp,$1) RETURNING *             |                    0 |
       |      | persoon      | INSERT INTO public.lo3_pl_persoon(pl_id,stapel_nr,volg_nr,persoon_type,burger_service_nr) VALUES($1,$2,$3,$4,$5) | 9999,0,0,P,000000012 |
+
+  @integratie
+  Scenario: de {datum}( geboren) inwoner {aanduiding}
+    Gegeven <persoon beschrijving>
+    Als de sql statements gegenereerd uit de gegeven stappen zijn uitgevoerd
+    Dan heeft persoon 'P1' de volgende rij in tabel 'lo3_pl'
+      | pl_id | geheim_ind |
+      | P1    |          0 |
+    En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_persoon'
+      | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam | geboorte_datum  | geboorte_land_code | akte_nr |
+      | P1    |         0 |       0 | P            |         000000012 | P1             | <geboortedatum> |               6030 | 1_A____ |
+    En heeft persoon 'P1' de volgende rij in tabel 'lo3_pl_verblijfplaats'
+      | pl_id | volg_nr | inschrijving_gemeente_code |
+      | P1    |       0 |                       0518 |
+
+    Voorbeelden:
+      | persoon beschrijving                           | geboortedatum      |
+      | de vandaag 5 jaar geleden geboren inwoner 'P1' | vandaag - 5 jaar   |
+      | de 5 jaar geleden geboren inwoner 'P1'         | vandaag - 5 jaar   |
+      | de op 21 januari 2021 geboren inwoner 'P1'     |           20210121 |
+      | de op 21-01-2021 geboren inwoner 'P1'          |           20210121 |
+      | de op een onbekende datum geboren inwoner 'P1' |           00000000 |
+      | de minderjarige inwoner 'P1'                   | gisteren - 17 jaar |

--- a/features/step_definitions/expressief/gegeven-stepdefs-partner.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-partner.js
@@ -128,7 +128,7 @@ function gegevenDePersonenZijnGescheiden(context, aanduiding1, aanduiding2, data
 }
 
 Given('{aanduiding} en {aanduiding} zijn gescheiden', function (aanduiding1, aanduiding2) {
-    gegevenGescheidenOpDatum(aanduiding1, aanduiding2, 'gisteren - 1 jaar')
+    gegevenGescheidenOpDatum.call(this, aanduiding1, aanduiding2, 'gisteren - 1 jaar')
 });
 
 Given('{aanduiding} en {aanduiding} zijn (op ){dd-mm-yyyy datum} gescheiden', gegevenGescheidenOpDatum);

--- a/features/step_definitions/expressief/gegeven-stepdefs-partner.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-partner.js
@@ -90,10 +90,10 @@ function gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap(aanduidin
          datumVerbintenis, '0518', '6030', soortVerbintenis);
 }
 
-Given('{aanduiding} en {aanduiding} zijn (met elkaar ){vandaag, gisteren of morgen x jaar geleden} {soort verbintenis}', gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap);
-Given('{aanduiding} en {aanduiding} zijn (met elkaar ){vandaag, gisteren of morgen - x jaar} {soort verbintenis}', gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap);
-Given('{aanduiding} en {aanduiding} zijn (met elkaar ){relatieve datum} {soort verbintenis}', gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap);
-Given('{aanduiding} en {aanduiding} zijn {soort verbintenis} {dd-mm-yyyy datum}', function(aanduiding1, aanduiding2, soortVerbintenis, datum) {
+Given('{aanduiding} en {aanduiding} zijn (met elkaar ){vandaag, gisteren of morgen x jaar geleden} (opnieuw ){soort verbintenis}', gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap);
+Given('{aanduiding} en {aanduiding} zijn (met elkaar ){vandaag, gisteren of morgen - x jaar} (opnieuw ){soort verbintenis}', gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap);
+Given('{aanduiding} en {aanduiding} zijn (met elkaar ){relatieve datum} (opnieuw ){soort verbintenis}', gegevenDePersonenZijnOpDatumGehuwdOfGeregistreerdPartnerschap);
+Given('{aanduiding} en {aanduiding} zijn (opnieuw ){soort verbintenis} {dd-mm-yyyy datum}', function(aanduiding1, aanduiding2, soortVerbintenis, datum) {
     gegevenDePersonenZijnGehuwdOfGeregistreerdPartnerschap(this.context, aanduiding1, aanduiding2,
          datum, '0518', '6030', soortVerbintenis);
 });

--- a/features/step_definitions/expressief/gegeven-stepdefs-partner.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-partner.js
@@ -127,34 +127,28 @@ function gegevenDePersonenZijnGescheiden(context, aanduiding1, aanduiding2, data
     );
 }
 
-Given(/^'(.*)' en '(.*)' zijn gescheiden$/, function (aanduiding1, aanduiding2) {
-    const datumScheiding = 'gisteren - 1 jaar';
+Given('{aanduiding} en {aanduiding} zijn gescheiden', function (aanduiding1, aanduiding2) {
+    gegevenGescheidenOpDatum(aanduiding1, aanduiding2, 'gisteren - 1 jaar')
+});
+
+Given('{aanduiding} en {aanduiding} zijn (op ){dd-mm-yyyy datum} gescheiden', gegevenGescheidenOpDatum);
+Given('{aanduiding} en {aanduiding} zijn (op ){dd maand yyyy datum} gescheiden', gegevenGescheidenOpDatum);
+Given('{aanduiding} en {aanduiding} zijn {vandaag, gisteren of morgen x jaar geleden} gescheiden', gegevenGescheidenOpDatum);
+Given('{aanduiding} en {aanduiding} zijn {vandaag, gisteren of morgen - x jaar} gescheiden', gegevenGescheidenOpDatum);
+
+function gegevenGescheidenOpDatum(aanduidingPartner1, aanduidingPartner2, datum) {
     const plaatsScheiding = '0518';
     const landScheiding = '6030';
 
     const scheidingData = arrayOfArraysToDataTable([
-        ['datum ontbinding huwelijk/geregistreerd partnerschap (07.10)', datumScheiding],
+        ['datum ontbinding huwelijk/geregistreerd partnerschap (07.10)', datum],
         ['plaats ontbinding huwelijk/geregistreerd partnerschap (07.20)', plaatsScheiding],
         ['land ontbinding huwelijk/geregistreerd partnerschap (07.30)', landScheiding],
         ['soort verbintenis (15.10)', VerbintenisSoort.Huwelijk]
-    ])
+    ]);
 
-    gegevenDePersonenZijnGescheiden(this.context, aanduiding1, aanduiding2, scheidingData);
-});
-
-Given(/^'(.*)' en '(.*)' zijn (.*) gescheiden$/, function (aanduiding1, aanduiding2, relatieveDatum) {
-    const plaatsScheiding = '0518';
-    const landScheiding = '6030';
-
-    const scheidingData = arrayOfArraysToDataTable([
-        ['datum ontbinding huwelijk/geregistreerd partnerschap (07.10)', relatieveDatum],
-        ['plaats ontbinding huwelijk/geregistreerd partnerschap (07.20)', plaatsScheiding],
-        ['land ontbinding huwelijk/geregistreerd partnerschap (07.30)', landScheiding],
-        ['soort verbintenis (15.10)', VerbintenisSoort.Huwelijk]
-    ])
-
-    gegevenDePersonenZijnGescheiden(this.context, aanduiding1, aanduiding2, scheidingData);
-});
+    gegevenDePersonenZijnGescheiden(this.context, aanduidingPartner1, aanduidingPartner2, scheidingData);
+}
 
 Given(/^'(.*)' en '(.*)' zijn gescheiden met de volgende gegevens$/, function (aanduiding1, aanduiding2, dataTable) {
     gegevenDePersonenZijnGescheiden(this.context, aanduiding1, aanduiding2, dataTable);

--- a/features/step_definitions/expressief/gegeven-stepdefs-persoon.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-persoon.js
@@ -120,7 +120,7 @@ Given('de persoon {aanduiding}', function (aanduiding) {
 function gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn(geboortedatum, persoonAanduiding) {
     gegevenDePersoon(this.context, persoonAanduiding, genereerBurgerservicenummer(this.context), geboortedatum, '6030', undefined, undefined);
 
-    verblijfplaats = [
+    const verblijfplaats = [
         ['gemeente van inschrijving (09.10)', '0518']
     ]
     createVerblijfplaats(getPersoon(this.context, persoonAanduiding), arrayOfArraysToDataTable(verblijfplaats))

--- a/features/step_definitions/expressief/gegeven-stepdefs-persoon.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-persoon.js
@@ -1,6 +1,6 @@
 const { Given } = require('@cucumber/cucumber');
 const { arrayOfArraysToDataTable } = require('../dataTableFactory');
-const { createPersoon, aanvullenPersoon } = require('../persoon-2');
+const { createPersoon, aanvullenPersoon, createVerblijfplaats } = require('../persoon-2');
 const { getPersoon } = require('../contextHelpers');
 const { selectFirstOrDefault } = require('../postgresqlHelpers-2');
 const { genereerAktenummer, AkteTypes, genereerBurgerservicenummer } = require('../generators');
@@ -116,6 +116,21 @@ Given('de {meer- of minderjarige} {geslachtsaanduiding}( ){string}', gegevenDeOp
 Given('de persoon {aanduiding}', function (aanduiding) {
     gegevenDePersoon(this.context, aanduiding, genereerBurgerservicenummer(this.context), undefined, undefined, undefined, undefined);
 });
+
+function gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn(geboortedatum, persoonAanduiding) {
+    gegevenDePersoon(this.context, persoonAanduiding, genereerBurgerservicenummer(this.context), geboortedatum, '6030', undefined, undefined);
+
+    verblijfplaats = [
+        ['gemeente van inschrijving (09.10)', '0518']
+    ]
+    createVerblijfplaats(getPersoon(this.context, persoonAanduiding), arrayOfArraysToDataTable(verblijfplaats))
+}
+
+Given('de {vandaag, gisteren of morgen x jaar geleden} geboren inwoner {string}', gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn);
+Given('de {dd maand yyyy datum} geboren inwoner {string}', gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn);
+Given('de {onbekende datum} geboren inwoner {string}', gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn);
+Given('de {dd-mm-yyyy datum} geboren inwoner {string}', gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn);
+Given('de {meer- of minderjarige} inwoner {string}', gegevenDeOpDatumInNederlandGeborenEnVerblijvendePersoonMetGegenereerdeBsn);
 
 module.exports = {
     gegevenDePersoon

--- a/features/step_definitions/expressief/gegeven-stepdefs-persoon.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-persoon.js
@@ -111,6 +111,7 @@ Given('de {vandaag, gisteren of morgen x jaar geleden} geboren {geslachtsaanduid
 Given('de {dd maand yyyy datum} geboren {geslachtsaanduiding}( ){string}', gegevenDeOpDatumInNederlandGeborenPersoonMetGegenereerdeBsn);
 Given('de {onbekende datum} geboren {geslachtsaanduiding}( ){string}', gegevenDeOpDatumInNederlandGeborenPersoonMetGegenereerdeBsn);
 Given('de {dd-mm-yyyy datum} geboren {geslachtsaanduiding}( ){string}', gegevenDeOpDatumInNederlandGeborenPersoonMetGegenereerdeBsn);
+Given('de {meer- of minderjarige} {geslachtsaanduiding}( ){string}', gegevenDeOpDatumInNederlandGeborenPersoonMetGegenereerdeBsn);
 
 Given('de persoon {aanduiding}', function (aanduiding) {
     gegevenDePersoon(this.context, aanduiding, genereerBurgerservicenummer(this.context), undefined, undefined, undefined, undefined);

--- a/features/step_definitions/expressief/gegeven-stepdefs-verblijfplaats.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-verblijfplaats.js
@@ -1,5 +1,5 @@
 const { Given } = require('@cucumber/cucumber');
-const { createVerblijfplaats, wijzigVerblijfplaats } = require('../persoon-2');
+const { createVerblijfplaats, wijzigVerblijfplaats, aanvullenInschrijving } = require('../persoon-2');
 const { getPersoon } = require('../contextHelpers');
 const { arrayOfArraysToDataTable } = require('../dataTableFactory');
 const { toDateOrString, toBRPDate } = require('../brpDatum');
@@ -244,4 +244,31 @@ module.exports = {
 
 Given('is ingeschreven met een tijdelijke verblijfplaats in Nederland', function () {
     // Later desgewenst invullen, wanneer we iets doen met tijdelijke verblijfplaats
+});
+
+Given('{vandaag, gisteren of morgen x jaar geleden} is geconstateerd dat {aanduiding} behoort tot de categorie NAVO-militair', function(relatieveDatum, aanduidingPersoon) {
+    const redenOpschorting = 'M';
+
+    const verblijfplaats = arrayOfArraysToDataTable([
+        ['gemeente van inschrijving (09.10)', '0518'],
+        ['land adres buitenland (13.10)', '0000'],
+        ['datum aanvang adres buitenland (13.20)', relatieveDatum],
+        ['aangifte adreshouding (72.10)', 'B']
+    ]);
+
+    const persoon = getPersoon(this.context, aanduidingPersoon)
+
+    if (!persoon.verblijfplaats || persoon.verblijfplaats==[]) {
+        createVerblijfplaats(persoon, verblijfplaats);
+    } else {
+        wijzigVerblijfplaats(persoon, verblijfplaats, false);
+    }
+
+    aanvullenInschrijving(
+        persoon,
+        arrayOfArraysToDataTable([
+            ['datum opschorting bijhouding (67.10)', relatieveDatum],
+            ['reden opschorting bijhouding (67.20)', redenOpschorting]
+        ])
+    );
 });

--- a/features/step_definitions/expressief/gegeven-stepdefs-verblijfplaats.js
+++ b/features/step_definitions/expressief/gegeven-stepdefs-verblijfplaats.js
@@ -241,3 +241,7 @@ module.exports = {
     gegevenDePersoonIsIngeschrevenInGemeente,
     gegevenDePersoonIsIngeschrevenInDeBrp
 }
+
+Given('is ingeschreven met een tijdelijke verblijfplaats in Nederland', function () {
+    // Later desgewenst invullen, wanneer we iets doen met tijdelijke verblijfplaats
+});

--- a/features/step_definitions/parameter-types.js
+++ b/features/step_definitions/parameter-types.js
@@ -112,6 +112,23 @@ defineParameterType({
     regexp: /(gisteren|vandaag|morgen|deze maand|vorige maand|volgende maand)/
 });
 
+function jarigheidGeboorteDatum(omschrijvingLeeftijd) {
+    const omschrijvingLeeftijdMap = new Map([
+        ['minderjarige', 'gisteren - 17 jaar'],
+        ['meerderjarige', 'gisteren - 45 jaar']
+    ]);
+
+    return omschrijvingLeeftijdMap.get(omschrijvingLeeftijd) || omschrijvingLeeftijd
+}
+
+defineParameterType({
+    name: 'meer- of minderjarige',
+    regexp: /(minderjarige|meerderjarige)/,
+    transformer(omschrijvingLeeftijd) {
+        return jarigheidGeboorteDatum(omschrijvingLeeftijd);
+    }
+});
+
 function toGeslachtsaanduiding(omschrijvingGeslacht) {
     const geslachtMap = new Map([
         ['man', 'M'],


### PR DESCRIPTION
- gegeven stap voor opgeven huwelijk met optioneel "opnieuw" zodat tekstueel duidelijk is dat het hertrouwen/reparatiehuwelijk betreft en dezelfde stap gebruikt kan worden
- gegeven stap voor aangeven dat er tijdelijke verblijfplaats is opgegeven. stap doet nu niks
- gegeven stap dat opschorting voor NAVO militair is. wijzigt opschorting bijhouding en verblijfplaats
- herschrijven stappen voor scheiden zodat ook op exacte datum kan worden opgegeven (met optioneel woord "op")
- gegeven stap voor opvoeren persoon als meerderjarige of minderjarige man of vrouw
- nieuwe stap voor opvoeren inwoner met geboortedatum zodat er geen aparte stap voor inschrijving in Nederlandse gemeente (Gegeven is ingeschreven in de BRP) meer nodig is