### PR TITLE
chore: dan heeft 'persoon aanduiding' 'gegevensgroep collectie' met de volgende gegevens stap definitie

### DIFF
--- a/features/docs/dan-stap-definities-persoon.feature
+++ b/features/docs/dan-stap-definities-persoon.feature
@@ -239,3 +239,36 @@ Functionaliteit: Persoon dan stap definities
     | naam          | waarde |
     | geslachtsnaam | Jansen |
     En heeft de persoon geen 'geboorte' gegevens
+
+  Scenario: Dan heeft '[persoon aanduiding]' '[gegevensgroep collectie]' met de volgende gegevens
+    Gegeven de response body is gelijk aan
+      """
+      {
+        "personen": [
+          {
+            "<gegevensgroep collectie>": [
+              {
+                "naam": {
+                  "geslachtsnaam": "Jansen"
+                }
+              },
+              {
+                "naam": {
+                  "geslachtsnaam": "Pietersen"
+                }
+              }
+            ]
+          }
+        ]
+      }
+      """
+    Dan heeft 'Jan' '<gegevensgroep collectie>' met de volgende gegevens
+      | naam.geslachtsnaam |
+      | Jansen             |
+      | Pietersen          |
+
+    Voorbeelden:
+      | gegevensgroep collectie |
+      | kinderen                |
+      | ouders                  |
+      | partners                |

--- a/features/step_definitions/dan-stepdefs-persoon.js
+++ b/features/step_definitions/dan-stepdefs-persoon.js
@@ -4,7 +4,8 @@ const { createCollectieObject,
         createObjectVeldInLastCollectieObject } = require('./dataTable2ObjectFactory')
 const { getBsn,
         getPersoon } = require('./contextHelpers');
-const { createObjectFrom } = require('./dataTable2Object');
+const { createObjectFrom,
+        createObjectArrayFrom } = require('./dataTable2Object');
     
 Then(/^heeft de response ?(?:nog)? een persoon met ?(?:alleen)? de volgende gegevens$/, function (dataTable) {
     this.context.verifyResponse = true;
@@ -62,8 +63,8 @@ function createExpectedPersoon(context, persoonAanduiding) {
             id: persoonAanduiding // tijdelijk persoonAanduiding toevoegen om in volgende dan stap definities de correcte expected persoon te kunnen vinden
     };
 
-    if (context.isStapDocumentatieScenario ||
-        context.fieldsHasBurgerservicenummer) {
+    if ((context.isStapDocumentatieScenario ||
+        context.fieldsHasBurgerservicenummer) && persoon) {
         setProperty(expected, 'burgerservicenummer', getBsn(persoon));
     }
 
@@ -89,4 +90,17 @@ Then('heeft {string} de volgende {string} gegevens', function (persoonAanduiding
     }
 
     persoon[naamObjectProperty] = createObjectFrom(dataTable, true);
+});
+
+Then('heeft {aanduiding} {string} met de volgende gegevens', function (persoonAanduiding, naamObjectProperty, dataTable) {
+    initExpected(this.context);
+
+    let persoon = this.context.expected.personen.find(p => p.id === persoonAanduiding);
+    if(!persoon) {
+        persoon = createExpectedPersoon(this.context, persoonAanduiding);
+    }
+
+    if(['kinderen', 'ouders', 'partners'].includes(naamObjectProperty)) {
+        persoon[naamObjectProperty] = createObjectArrayFrom(dataTable, true);
+    }
 });


### PR DESCRIPTION
Om een scenario oude variant

```
  Scenario: Leveren van voorvoegsel van naam ouder 2 als beide ouders een voorvoegsel hebben
    Gegeven de persoon met burgerservicenummer '000000012' heeft een ouder '1' met de volgende gegevens
      | voorvoegsel (02.30) | geslachtsnaam (02.40) |
      | van                 | Case                  |
    En de persoon heeft een ouder '2' met de volgende gegevens
      | voorvoegsel (02.30) | geslachtsnaam (02.40) |
      | den                 | Test                  |
    Als personen wordt gezocht met de volgende parameters
      | naam                | waarde                          |
      | type                | RaadpleegMetBurgerservicenummer |
      | burgerservicenummer | 000000012                       |
      | fields              | ouders.ouderAanduiding,ouders.naam.geslachtsnaam,ouders.naam.voorvoegsel |
    Dan heeft de response een persoon met een 'ouder' met de volgende gegevens
      | naam               | waarde |
      | ouderAanduiding    | 1      |
      | naam.voorvoegsel   | van    |
      | naam.geslachtsnaam | Case   |
    En heeft de persoon een 'ouder' met de volgende gegevens
      | naam               | waarde |
      | ouderAanduiding    | 2      |
      | naam.voorvoegsel   | den    |
      | naam.geslachtsnaam | Test   |
```

expressief te beschrijven

```
  Scenario: Leveren van voorvoegsel van naam ouder 2 als beide ouders een voorvoegsel hebben
    Gegeven de persoon 'Saskia'
    * heeft de volgende gegevens
      | geslachtsnaam (02.40) |
      | Case                  |
    En de persoon 'Jan'
    * heeft de volgende gegevens
      | voorvoegsel (02.30) | geslachtsnaam (02.40) |
      | den                 | Test                  |
    En de persoon 'Robin'
    * heeft '<ouder 1>' en '<ouder 2>' als ouders
    Als 'ouders.ouderAanduiding,ouders.naam.geslachtsnaam,ouders.naam.voorvoegsel' wordt gevraagd van personen gezocht met burgerservicenummer van 'Robin'
    Dan heeft 'Robin' 'ouders' met de volgende gegevens
      | ouderAanduiding      | naam.geslachtsnaam | naam.voorvoegsel |
      | <aanduiding ouder 2> | Test               | den              |
      | <aanduiding ouder 1> | Case               |                  |

    Voorbeelden:
      | ouder 1 | ouder 2 | aanduiding ouder 1 | aanduiding ouder 2 |
      | Saskia  | Jan     |                  1 |                  2 |
      | Jan     | Saskia  |                  2 |                  1 |
```
