### PR TITLE
ci: genereer test rapport met junit xml formatter zodat deze met test-reporter action kan worden omgezet in GitHub Summary

### DIFF
--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -17,7 +17,7 @@ runs:
       with:
         name: Cucumber JS Test Reports
         report-title: Cucumber Test Reports
-        artifact: /test-result-(.*)/
+        path: ./test-reports/cucumber-js/**/*.xml
         reporter: java-junit
         only-summary: true
 

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -18,7 +18,7 @@ runs:
         name: Cucumber JS Test Reports
         report-title: Cucumber Test Reports
         path: ./test-reports/cucumber-js/**/*.xml
-        artifact: /.*//test-reports-(.*)/
+        artifact: /.*//test-result-(.*)/
         reporter: java-junit
         only-summary: true
 

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -24,6 +24,6 @@ runs:
       uses: dorny/test-reporter@v2
       with:
         name: Cucumber JS Test Reports
-        path: ./test-reports/**/*.xml
+        path: ./test-reports/cucumber-js/**/*.xml
         reporter: java-junit
         only-summary: true

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -23,7 +23,7 @@ runs:
         only-summary: true
 
     - name: Genereer en publiceer validatie summary in de worfklow job summary
-      if: ${{ failed() }}
+      if: ${{ failure() }}
       run: |
           node ./scripts/generate-step-summary.js
           cat ./test-reports/cucumber-js/step-summary.txt >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -27,4 +27,5 @@ runs:
         report-title: Cucumber Test Reports
         path: ./test-reports/cucumber-js/**/*.xml
         reporter: java-junit
-        only-summary: true
+        only-summary: false
+        list-tests: failed

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -17,7 +17,6 @@ runs:
       with:
         name: Cucumber JS Test Reports
         report-title: Cucumber Test Reports
-        path: ./test-reports/cucumber-js/**/*.xml
         artifact: /test-result-(.*)/
         reporter: java-junit
         only-summary: true

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -18,3 +18,12 @@ runs:
           node ./scripts/generate-step-summary.js
           cat ./test-reports/cucumber-js/step-summary.txt >> $GITHUB_STEP_SUMMARY
       shell: bash
+
+    - name: Publiceer test rapportage
+      if: ${{ !cancelled() }}
+      uses: dorny/test-reporter@v2
+      with:
+        name: Cucumber JS Test Reports
+        path: ./test-reports/**/*.xml
+        reporter: java-junit
+        only-summary: true

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -11,14 +11,6 @@ runs:
       run: ./scripts/specs-verify.sh
       shell: bash
 
-    - name: Genereer en publiceer validatie summary in de worfklow job summary
-      if: ${{ !cancelled() }}
-      run: |
-          echo "### Cucumber Test Reports" >> $GITHUB_STEP_SUMMARY
-          node ./scripts/generate-step-summary.js
-          cat ./test-reports/cucumber-js/step-summary.txt >> $GITHUB_STEP_SUMMARY
-      shell: bash
-
     - name: Publiceer test rapportage
       if: ${{ !cancelled() }}
       uses: dorny/test-reporter@v2
@@ -27,5 +19,11 @@ runs:
         report-title: Cucumber Test Reports
         path: ./test-reports/cucumber-js/**/*.xml
         reporter: java-junit
-        only-summary: false
-        list-tests: failed
+        only-summary: true
+
+    - name: Genereer en publiceer validatie summary in de worfklow job summary
+      if: ${{ !cancelled() }}
+      run: |
+          node ./scripts/generate-step-summary.js
+          cat ./test-reports/cucumber-js/step-summary.txt >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -18,7 +18,7 @@ runs:
         name: Cucumber JS Test Reports
         report-title: Cucumber Test Reports
         path: ./test-reports/cucumber-js/**/*.xml
-        artifact: /.*//test-result-(.*)/
+        artifact: /test-result-(.*)/
         reporter: java-junit
         only-summary: true
 

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -18,11 +18,12 @@ runs:
         name: Cucumber JS Test Reports
         report-title: Cucumber Test Reports
         path: ./test-reports/cucumber-js/**/*.xml
+        artifact: /.*//test-reports-(.*)/
         reporter: java-junit
         only-summary: true
 
     - name: Genereer en publiceer validatie summary in de worfklow job summary
-      if: ${{ !cancelled() }}
+      if: ${{ failed() }}
       run: |
           node ./scripts/generate-step-summary.js
           cat ./test-reports/cucumber-js/step-summary.txt >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/valideer-functionele-specs/action.yml
+++ b/.github/actions/valideer-functionele-specs/action.yml
@@ -24,6 +24,7 @@ runs:
       uses: dorny/test-reporter@v2
       with:
         name: Cucumber JS Test Reports
+        report-title: Cucumber Test Reports
         path: ./test-reports/cucumber-js/**/*.xml
         reporter: java-junit
         only-summary: true

--- a/cucumber.js
+++ b/cucumber.js
@@ -26,7 +26,7 @@ module.exports = {
       },
       addAcceptGezagVersionHeader: true
     },
-    tags: 'not @skip-verify and not @deprecated and ((not @gezag-api and not @data-api) or @info-api)'
+    tags: 'not @skip-verify and not @stap-documentatie and not @deprecated and ((not @gezag-api and not @data-api) or @info-api)'
   },
   InfoApiDeprecated: {
     worldParameters: {
@@ -38,7 +38,7 @@ module.exports = {
       },
       addAcceptGezagVersionHeader: false
     },
-    tags: 'not @skip-verify and ((@deprecated and ((not @data-api and not @gezag-api) or @info-api)) or (not @deprecated and not @nieuw and ((not @data-api and not @gezag-api) or @info-api)))'
+    tags: 'not @skip-verify and not @stap-documentatie and ((@deprecated and ((not @data-api and not @gezag-api) or @info-api)) or (not @deprecated and not @nieuw and ((not @data-api and not @gezag-api) or @info-api)))'
   },
   DataApi: {
     worldParameters: {
@@ -49,7 +49,7 @@ module.exports = {
       },
       addAcceptGezagVersionHeader: true
     },
-    tags: 'not @skip-verify and not @deprecated and ((not @gezag-api and not @info-api) or @data-api)'
+    tags: 'not @skip-verify and not @stap-documentatie and not @deprecated and ((not @gezag-api and not @info-api) or @data-api)'
   },
   DataApiDeprecated: {
     worldParameters: {
@@ -61,7 +61,7 @@ module.exports = {
       },
       addAcceptGezagVersionHeader: false
     },
-    tags: 'not @skip-verify and ((@deprecated and ((not @gezag-api and not @info-api) or @data-api)) or (not @deprecated and not @nieuw and ((not @gezag-api and not @info-api) or @data-api)))'
+    tags: 'not @skip-verify and not @stap-documentatie and ((@deprecated and ((not @gezag-api and not @info-api) or @data-api)) or (not @deprecated and not @nieuw and ((not @gezag-api and not @info-api) or @data-api)))'
   },
   GezagApi: {
     worldParameters: {
@@ -96,8 +96,9 @@ module.exports = {
       oAuth: {
         enable: true
       },
-      addAcceptGezagVersionHeader: true
+      addAcceptGezagVersionHeader: false,
+      logFileToAssert: './test-data/logs/brp-autorisatie-protocollering.json'
     },
-    tags: 'not @skip-verify and not @deprecated and not @gezag-api and not @data-api'
+    tags: 'not @skip-verify and not @stap-documentatie and not @deprecated and not @gezag-api and not @data-api'
   }
 }

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -22,7 +22,7 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
       | P2    |          0 |
     En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
-      | P2    |         0 |       0 | P            |         000000024 | P2             |
+      | P2    |         0 |       0 | P            |         000000024 | P3             |
 
   @integratie
   Abstract Scenario: (de) persoon '[persoon aanduiding]' heeft de volgende gegevens

--- a/features/docs/gegeven-stap-definities-persoon.feature
+++ b/features/docs/gegeven-stap-definities-persoon.feature
@@ -22,7 +22,7 @@ Functionaliteit: Persoon, Inschrijving gegeven stap definities
       | P2    |          0 |
     En heeft persoon 'P2' de volgende rij in tabel 'lo3_pl_persoon'
       | pl_id | stapel_nr | volg_nr | persoon_type | burger_service_nr | geslachts_naam |
-      | P2    |         0 |       0 | P            |         000000024 | P3             |
+      | P2    |         0 |       0 | P            |         000000024 | P2             |
 
   @integratie
   Abstract Scenario: (de) persoon '[persoon aanduiding]' heeft de volgende gegevens

--- a/features/step_definitions/als-stepdefs.js
+++ b/features/step_definitions/als-stepdefs.js
@@ -248,20 +248,32 @@ function createDataTableForRequest(parameterNames, fields) {
             return undefined;
     }
 }
-        
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function handleRequestWithParameters(context, endpoint, parametersDataTable) {
     initializeAfnemerIdAndGemeenteCode(context);
 
+    let mustSleep = false;
     if(context.gezag !== undefined) {
         fs.writeFileSync(context.gezagDataPath, JSON.stringify(context.gezag, null, '\t'));
+        mustSleep = true;
     }
     if(context.downstreamApiResponseHeaders !== undefined) {
         fs.writeFileSync(context.downstreamApiDataPath + '/response-headers.json',
                          JSON.stringify(context.downstreamApiResponseHeaders[0], null, '\t'));
+        mustSleep = true;
     }
     if(context.downstreamApiResponseBody !== undefined) {
         fs.writeFileSync(context.downstreamApiDataPath + '/response-body.json',
                          context.downstreamApiResponseBody);
+        mustSleep = true;
+    }
+    if(mustSleep) {
+        // wait 15 ms to ensure the files are written before the request is made
+        await sleep(15);
     }
 
     addDefaultAutorisatieSettings(context, context.afnemerID);

--- a/features/step_definitions/dan-stepdefs-response.js
+++ b/features/step_definitions/dan-stepdefs-response.js
@@ -10,6 +10,13 @@ Then(/^heeft de response de volgende headers$/, function (dataTable) {
     });
 });
 
+Then('heeft de response geen {string} header', function (headerNaam) {
+    const headers = this.context.response.headers;
+
+    const header = headers[headerNaam];
+    should.not.exist(header);
+});
+
 Then('bevat de request naar de gezag API de header {string} met waarde {string}', function (headerNaam, headerWaarde) {
     const headers = this.context.response.headers;
 

--- a/scripts/process-cucumber-file.js
+++ b/scripts/process-cucumber-file.js
@@ -11,7 +11,7 @@ function processFile(inputPath, outputPath, caption) {
     }
 
     let finalOutput = `#### ${caption}\n`;
-    finalOutput += footerLines[0] + '\n' + footerLines[1] +'\n' + '\n';
+    finalOutput += footerLines[0] + '\n' + '\n';
 
     lines.forEach((line) => {
         const match = line.match(/^\d+\) Scenario: .*# (.+:\d+)/);

--- a/scripts/process-cucumber-file.js
+++ b/scripts/process-cucumber-file.js
@@ -11,7 +11,7 @@ function processFile(inputPath, outputPath, caption) {
     }
 
     let finalOutput = `#### ${caption}\n`;
-    finalOutput += footerLines.join('\n') + '\n';
+    finalOutput += footerLines[0] + '\n' + footerLines[1] +'\n' + '\n';
 
     lines.forEach((line) => {
         const match = line.match(/^\d+\) Scenario: .*# (.+:\d+)/);

--- a/scripts/specs-verify.sh
+++ b/scripts/specs-verify.sh
@@ -1,43 +1,60 @@
 #!/bin/bash
 
+EXIT_CODE=0
+
 npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-zonder-dependency-integratie.json \
+                -f junit:./test-reports/cucumber-js/step-definitions/test-result-zonder-dependency-integratie-unit.xml \
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-zonder-dependency-integratie-summary.txt \
                 -f summary \
                 features/docs \
                 -p UnitTest \
                 > /dev/null
+if [ $? -ne 0 ]; then EXIT_CODE=1; fi
 
 npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-integratie.json \
+                -f junit:./test-reports/cucumber-js/step-definitions/test-result-integratie-unit.xml \
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-integratie-summary.txt \
                 -f summary \
                 features/docs \
                 -p Integratie \
                 > /dev/null
+if [ $? -ne 0 ]; then EXIT_CODE=1; fi
 
 npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-informatie-api.json \
+                -f junit:./test-reports/cucumber-js/step-definitions/test-result-informatie-api-unit.xml \
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-informatie-api-summary.txt \
                 -f summary \
                 features/docs \
                 -p InfoApi \
                 > /dev/null
+if [ $? -ne 0 ]; then EXIT_CODE=1; fi
 
 npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-data-api.json \
+                -f junit:./test-reports/cucumber-js/step-definitions/test-result-data-api-unit.xml \
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-data-api-summary.txt \
                 -f summary \
                 features/docs \
                 -p DataApi \
                 > /dev/null
+if [ $? -ne 0 ]; then EXIT_CODE=1; fi
 
 npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-gezag-api.json \
+                -f junit:./test-reports/cucumber-js/step-definitions/test-result-gezag-api-unit.xml \
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-gezag-api-summary.txt \
                 -f summary \
                 features/docs \
                 -p GezagApi \
                 > /dev/null
+if [ $? -ne 0 ]; then EXIT_CODE=1; fi
 
 npx cucumber-js -f json:./test-reports/cucumber-js/step-definitions/test-result-gezag-api-deprecated.json \
+                -f junit:./test-reports/cucumber-js/step-definitions/test-result-gezag-api-deprecated-unit.xml \
                 -f summary:./test-reports/cucumber-js/step-definitions/test-result-gezag-api-deprecated-summary.txt \
                 -f summary \
                 features/docs \
                 -p GezagApiDeprecated \
                 > /dev/null
+if [ $? -ne 0 ]; then EXIT_CODE=1; fi
+
+# Exit with error code if any command failed
+exit $EXIT_CODE


### PR DESCRIPTION
Zie GitHub Summary voor een run met alle testen die slagen: https://github.com/BRP-API/brp-shared/actions/runs/16027195394

en Github summary met een falende test: https://github.com/BRP-API/brp-shared/actions/runs/16026620490

De oude test rapport wordt alleen gegenereerd als er tests falen. Dit omdat ik het niet voor elkaar krijg om met de test-reporter een lijst met de falende tests kan genereren